### PR TITLE
iwiki Phase B: lint/parser fix, engine test suite, robustness hardening (v0.6.0)

### DIFF
--- a/docs/superpowers/plans/2026-06-22-iwiki-evaluation-improvements.md
+++ b/docs/superpowers/plans/2026-06-22-iwiki-evaluation-improvements.md
@@ -13,6 +13,10 @@ review:
 chain:
   intent: docs/superpowers/intents/2026-06-17-iwiki-intent.md
   spec:   docs/superpowers/specs/2026-06-22-iwiki-evaluation-improvements-design.md
+result_check:
+  verdict: OK
+  plan_hash: 82f6bc2121fd7241
+  last_run: 2026-06-22
 ---
 
 # iwiki Plugin Improvements (Phase B) Implementation Plan

--- a/docs/superpowers/reports/results/2026-06-22-iwiki-evaluation-improvements-result-check.html
+++ b/docs/superpowers/reports/results/2026-06-22-iwiki-evaluation-improvements-result-check.html
@@ -1,0 +1,585 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Result Check · iwiki Evaluation Improvements · 2026-06-22</title>
+<style>
+/* ── Themes ── */
+:root{
+  --bg:#f6f7fb; --surface:#ffffff; --fg:#2b2b3a; --muted:#6b6b80;
+  --accent:#5c6bc0; --accent-2:#3949ab; --border:#d6d8e6; --line:#9aa0b4; --zebra:#eef0f8;
+  --ok:#43a047; --ok-2:#2e7d32; --warn:#fb8c00; --warn-2:#ef6c00; --danger:#e53935; --danger-2:#c62828;
+  --shadow:rgba(40,40,80,.18);
+}
+body:has(#theme-toggle:checked){
+  --bg:#181825; --surface:#262637; --fg:#cdd6f4; --muted:#a6adc8;
+  --accent:#89b4fa; --accent-2:#5e95f0; --border:#3a3b52; --line:#6c7086; --zebra:#21222f;
+  --ok:#a6e3a1; --ok-2:#74c46e; --warn:#f9e2af; --warn-2:#f5c95b; --danger:#f38ba8; --danger-2:#e8638a;
+  --shadow:rgba(0,0,0,.45);
+}
+body{
+  margin:0 auto; padding:1.5rem 2rem 4rem; max-width:1100px;
+  font:16px/1.55 system-ui, sans-serif;
+  background:
+    radial-gradient(1200px 500px at 100% -10%, color-mix(in srgb,var(--accent) 10%, transparent), transparent),
+    var(--bg);
+  color:var(--fg);
+  transition:background .3s, color .3s;
+}
+.theme-btn{
+  position:sticky; top:.5rem; float:right;
+  cursor:pointer; user-select:none;
+  padding:.25rem .6rem; border:1px solid var(--border); border-radius:6px;
+  background:var(--surface);
+}
+
+/* ── Typography ── */
+h1{ font-size:1.6rem; margin:.5rem 0 .25rem; color:var(--accent); }
+h2{ font-size:1.2rem; margin:2rem 0 .6rem; border-bottom:2px solid var(--border); padding-bottom:.3rem; color:var(--accent); }
+h3{ font-size:1rem; margin:1.2rem 0 .4rem; color:var(--fg); }
+.lead{ font-size:1.08rem; }
+.sub{ color:var(--muted); font-size:.9rem; margin:.15rem 0; }
+.note{ border-left:4px solid var(--accent); padding:.55rem 1rem; margin:1rem 0;
+  background:color-mix(in srgb, var(--accent) 8%, var(--surface)); border-radius:0 8px 8px 0;
+  box-shadow:0 1px 8px var(--shadow); }
+.note-warn{ border-left:4px solid var(--warn); padding:.55rem 1rem; margin:1rem 0;
+  background:color-mix(in srgb, var(--warn) 8%, var(--surface)); border-radius:0 8px 8px 0;
+  box-shadow:0 1px 8px var(--shadow); }
+.note-ok{ border-left:4px solid var(--ok); padding:.55rem 1rem; margin:1rem 0;
+  background:color-mix(in srgb, var(--ok) 8%, var(--surface)); border-radius:0 8px 8px 0;
+  box-shadow:0 1px 8px var(--shadow); }
+details{ background:var(--surface); border:1px solid var(--border); border-radius:10px;
+  padding:.7rem 1rem; margin:.5rem 0; box-shadow:0 1px 8px var(--shadow); }
+details summary{ cursor:pointer; font-weight:600; color:var(--accent); }
+details[open] summary{ margin-bottom:.55rem; }
+ul.tight li{ margin:.28rem 0; }
+code{ background:color-mix(in srgb, var(--accent) 10%, var(--surface));
+  border-radius:4px; padding:.05rem .35rem; font-size:.88em; font-family:monospace; }
+
+/* ── Badges ── */
+.badge{ display:inline-block; font-size:.72rem; padding:.05rem .5rem; border-radius:999px;
+  border:1px solid var(--border); font-weight:600; }
+.badge-ok  { color:var(--ok-2);     border-color:var(--ok);     background:color-mix(in srgb,var(--ok) 10%,var(--surface)); }
+.badge-warn{ color:var(--warn-2);   border-color:var(--warn);   background:color-mix(in srgb,var(--warn) 10%,var(--surface)); }
+.badge-err { color:var(--danger-2); border-color:var(--danger); background:color-mix(in srgb,var(--danger) 10%,var(--surface)); }
+.badge-info{ color:var(--accent-2); border-color:var(--accent); background:color-mix(in srgb,var(--accent) 10%,var(--surface)); }
+.badge-na  { color:var(--muted);    border-color:var(--border); background:var(--zebra); }
+
+/* ── Tables ── */
+.rpt-table{ border-collapse:separate; border-spacing:0; width:100%; background:var(--surface);
+  margin:1rem 0; font-size:.91rem; border:1px solid var(--border); border-radius:10px;
+  overflow:hidden; box-shadow:0 2px 12px var(--shadow); }
+.rpt-table th, .rpt-table td{ border-bottom:1px solid var(--border); padding:.45rem .75rem;
+  text-align:left; vertical-align:top; }
+.rpt-table tbody tr:last-child td{ border-bottom:none; }
+.rpt-table thead th{ background:var(--accent); color:var(--bg); position:sticky; top:0; }
+.rpt-table tbody tr:nth-child(even){ background:var(--zebra); }
+.rpt-table tbody tr:hover{ background:color-mix(in srgb, var(--accent) 12%, var(--surface)); }
+
+/* ── Verdict banner ── */
+.verdict-ok{
+  display:flex; align-items:center; gap:1rem;
+  background:color-mix(in srgb, var(--ok) 12%, var(--surface));
+  border:2px solid var(--ok); border-radius:12px;
+  padding:1rem 1.5rem; margin:1.5rem 0;
+  box-shadow:0 2px 12px var(--shadow);
+}
+.verdict-ok .v-icon{ font-size:2rem; }
+.verdict-ok .v-text{ }
+.verdict-ok .v-text strong{ font-size:1.2rem; color:var(--ok-2); }
+
+/* ── Chain flow ── */
+.rpt-flow{ display:flex; align-items:center; gap:0; margin:1rem 0; flex-wrap:wrap; }
+.rpt-flow .node{
+  background:var(--surface); color:var(--fg);
+  border:1px solid var(--border); border-radius:8px; padding:.5rem .85rem;
+  font-size:.88rem;
+}
+.rpt-flow .arrow{ flex:0 0 2.5rem; height:2px; background:var(--line); position:relative; }
+.rpt-flow .arrow::after{
+  content:""; position:absolute; right:0; top:-4px;
+  border:5px solid transparent; border-left-color:var(--line);
+}
+
+/* ── Summary counters ── */
+.counters{ display:flex; gap:1rem; flex-wrap:wrap; margin:1rem 0; }
+.counter-card{
+  flex:1 1 140px; background:var(--surface); border:1px solid var(--border);
+  border-radius:10px; padding:.8rem 1.2rem; text-align:center;
+  box-shadow:0 2px 8px var(--shadow);
+}
+.counter-card .num{ font-size:2rem; font-weight:700; line-height:1; }
+.counter-card .lbl{ font-size:.82rem; color:var(--muted); margin-top:.2rem; }
+.counter-card.ok   .num{ color:var(--ok-2); }
+.counter-card.warn .num{ color:var(--warn-2); }
+.counter-card.crit .num{ color:var(--danger-2); }
+.counter-card.part .num{ color:var(--accent-2); }
+
+/* ── Step coverage table status column ── */
+td.status-done { color:var(--ok-2);     font-weight:600; }
+td.status-part { color:var(--warn-2);   font-weight:600; }
+td.status-miss { color:var(--danger-2); font-weight:600; }
+td.status-na   { color:var(--muted); }
+td.status-rs   { color:var(--accent-2); font-weight:600; }
+
+/* ── Coverage progress bar ── */
+.prog-wrap{ background:var(--border); border-radius:999px; height:10px; margin:.3rem 0; overflow:hidden; }
+.prog-bar { height:100%; border-radius:999px; background:var(--ok); }
+.prog-bar.warn{ background:var(--warn); }
+</style>
+</head>
+<body>
+
+<input type="checkbox" id="theme-toggle" hidden>
+<label for="theme-toggle" class="theme-btn" title="Переключить тему">🌙 / ☀️</label>
+
+<main class="report">
+
+<h1>Result Check — iwiki Plugin Improvements (Phase B)</h1>
+<p class="sub">Дата проверки: <strong>2026-06-22</strong> &nbsp;·&nbsp; Body hash плана: <code>82f6bc2121fd7241</code></p>
+
+<!-- ═══ Verdict ═══ -->
+<div class="verdict-ok">
+  <div class="v-icon">✅</div>
+  <div class="v-text">
+    <strong>Вердикт: OK</strong><br>
+    Критических пропусков нет. Все обязательные шаги выполнены или обоснованно rescoped контроллером.
+    Итог: CRITICAL 0 · WARNING 2 · INFO 0.
+  </div>
+</div>
+
+<!-- ═══ Documents ═══ -->
+<h2>Документы</h2>
+<table class="rpt-table">
+  <thead><tr><th>Роль</th><th>Путь</th></tr></thead>
+  <tbody>
+    <tr><td>Plan</td><td><code>docs/superpowers/plans/2026-06-22-iwiki-evaluation-improvements.md</code></td></tr>
+    <tr><td>Spec</td><td><code>docs/superpowers/specs/2026-06-22-iwiki-evaluation-improvements-design.md</code></td></tr>
+    <tr><td>Intent</td><td><code>docs/superpowers/intents/2026-06-17-iwiki-intent.md</code></td></tr>
+    <tr><td>Diff base</td><td><code>git diff 22399849..HEAD</code> — 7 коммитов, 20 файлов изменено</td></tr>
+  </tbody>
+</table>
+
+<h3>Цепочка IDD</h3>
+<figure class="rpt-flow">
+  <div class="node">intent<br><small>2026-06-17-iwiki-intent.md</small></div>
+  <div class="arrow"></div>
+  <div class="node">spec<br><small>2026-06-22-iwiki-evaluation-improvements-design.md</small></div>
+  <div class="arrow"></div>
+  <div class="node">plan<br><small>2026-06-22-iwiki-evaluation-improvements.md</small></div>
+</figure>
+
+<h3>Коммиты в диапазоне (22399849..HEAD)</h3>
+<table class="rpt-table">
+  <thead><tr><th>Хэш</th><th>Тип</th><th>Описание</th></tr></thead>
+  <tbody>
+    <tr><td><code>d2905f77</code></td><td><span class="badge badge-ok">fix</span></td><td>ignore [[...]] inside code when parsing wiki-links</td></tr>
+    <tr><td><code>313fd231</code></td><td><span class="badge badge-info">feat</span></td><td>retry transient embedding-backend failures with backoff</td></tr>
+    <tr><td><code>9e1b6375</code></td><td><span class="badge badge-ok">fix</span></td><td>skip unreadable files in graph BFS; warn on corrupt session state</td></tr>
+    <tr><td><code>c930252a</code></td><td><span class="badge badge-na">style</span></td><td>remove dead import os in related.py</td></tr>
+    <tr><td><code>f548e3a7</code></td><td><span class="badge badge-info">test</span></td><td>characterization tests for chunk/store/search/lint</td></tr>
+    <tr><td><code>560a3b63</code></td><td><span class="badge badge-ok">fix</span></td><td>clarify config error; document canonical log schema</td></tr>
+    <tr><td><code>2181c9e0</code></td><td><span class="badge badge-info">docs</span></td><td>fix html-report orphan, refresh engine page for Phase B; bump to 0.6.0</td></tr>
+  </tbody>
+</table>
+
+<!-- ═══ Summary counters ═══ -->
+<h2>Сводка покрытия</h2>
+<div class="counters">
+  <div class="counter-card ok">
+    <div class="num">32</div>
+    <div class="lbl">DONE</div>
+  </div>
+  <div class="counter-card part">
+    <div class="num">1</div>
+    <div class="lbl">PARTIAL</div>
+  </div>
+  <div class="counter-card crit">
+    <div class="num">0</div>
+    <div class="lbl">MISSING</div>
+  </div>
+  <div class="counter-card warn">
+    <div class="num">0</div>
+    <div class="lbl">CRITICAL findings</div>
+  </div>
+  <div class="counter-card warn">
+    <div class="num">2</div>
+    <div class="lbl">WARNING findings</div>
+  </div>
+</div>
+
+<!-- ═══ Plan step coverage ═══ -->
+<h2>Покрытие шагов плана</h2>
+
+<details open>
+  <summary>Task 1 — Code-aware link parsing (P1) · все шаги DONE</summary>
+  <table class="rpt-table">
+    <thead><tr><th>#</th><th>Шаг</th><th>Статус</th><th>Доказательство в diff</th></tr></thead>
+    <tbody>
+      <tr>
+        <td>1</td><td>Добавить pytest dev dependency в pyproject.toml</td>
+        <td class="status-done">DONE</td>
+        <td><code>pyproject.toml</code>: добавлен <code>[dependency-groups] dev = ["pytest>=8"]</code></td>
+      </tr>
+      <tr>
+        <td>2–4</td><td>Sync env, написать failing test, проверить провал</td>
+        <td class="status-done">DONE</td>
+        <td><code>plugin/iwiki/engine/tests/test_links.py</code> создан с 5 тестами</td>
+      </tr>
+      <tr>
+        <td>5</td><td>Исправить links.py: добавить _strip_code(), _FENCE, _INLINE</td>
+        <td class="status-done">DONE</td>
+        <td><code>links.py</code> полностью переписан; <code>_strip_code()</code> вызывается в <code>parse_links()</code></td>
+      </tr>
+      <tr>
+        <td>6–7</td><td>Тесты проходят; lint не содержит false broken refs</td>
+        <td class="status-done">DONE</td>
+        <td>27/27 тестов PASSED; <code>lint</code>: <code>broken=[]</code></td>
+      </tr>
+      <tr>
+        <td>8</td><td>Коммит</td>
+        <td class="status-done">DONE</td>
+        <td>Коммит <code>d2905f77</code></td>
+      </tr>
+    </tbody>
+  </table>
+</details>
+
+<details open>
+  <summary>Task 2 — Embedding retry с backoff (P5) · все шаги DONE</summary>
+  <table class="rpt-table">
+    <thead><tr><th>#</th><th>Шаг</th><th>Статус</th><th>Доказательство в diff</th></tr></thead>
+    <tbody>
+      <tr>
+        <td>1</td><td>Написать test_embed.py (3 теста)</td>
+        <td class="status-done">DONE</td>
+        <td><code>tests/test_embed.py</code> создан: retry_succeeds, gives_up, 4xx_not_retried</td>
+      </tr>
+      <tr>
+        <td>2</td><td>Провалить тесты</td>
+        <td class="status-done">DONE</td>
+        <td>–</td>
+      </tr>
+      <tr>
+        <td>3</td><td>Реализовать retry в embed.py</td>
+        <td class="status-done">DONE</td>
+        <td><code>embed.py</code>: добавлены <code>_MAX_ATTEMPTS=3</code>, <code>_BACKOFF_BASE=0.5</code>, <code>_is_transient()</code>, retry loop с <code>time.sleep()</code></td>
+      </tr>
+      <tr>
+        <td>4</td><td>Тесты проходят</td>
+        <td class="status-done">DONE</td>
+        <td>3/3 PASSED</td>
+      </tr>
+      <tr>
+        <td>5</td><td>Коммит</td>
+        <td class="status-done">DONE</td>
+        <td>Коммит <code>313fd231</code></td>
+      </tr>
+    </tbody>
+  </table>
+</details>
+
+<details open>
+  <summary>Task 3 — Hardening related.py + iwiki_common (P5) · все шаги DONE</summary>
+  <table class="rpt-table">
+    <thead><tr><th>#</th><th>Шаг</th><th>Статус</th><th>Доказательство в diff</th></tr></thead>
+    <tbody>
+      <tr>
+        <td>1</td><td>Написать test_related.py и test_iwiki_common.py</td>
+        <td class="status-done">DONE</td>
+        <td>Оба файла созданы; 4 теста суммарно</td>
+      </tr>
+      <tr>
+        <td>2</td><td>Провалить тесты</td>
+        <td class="status-done">DONE</td>
+        <td>–</td>
+      </tr>
+      <tr>
+        <td>3</td><td>Исправить related.py: try/except OSError вместо os.path.exists</td>
+        <td class="status-done">DONE</td>
+        <td><code>related.py</code>: bare <code>open()</code> → <code>try/except OSError</code>; dead <code>import os</code> удалён (коммит <code>c930252a</code>)</td>
+      </tr>
+      <tr>
+        <td>4</td><td>Исправить iwiki_common.py: import sys + stderr warning</td>
+        <td class="status-done">DONE</td>
+        <td><code>iwiki_common.py</code>: добавлен <code>import sys</code>; <code>read_session()</code> предупреждает на stderr при corrupt JSON</td>
+      </tr>
+      <tr>
+        <td>5</td><td>Тесты проходят</td>
+        <td class="status-done">DONE</td>
+        <td>4/4 PASSED</td>
+      </tr>
+      <tr>
+        <td>6</td><td>Коммит</td>
+        <td class="status-done">DONE</td>
+        <td>Коммит <code>9e1b6375</code></td>
+      </tr>
+    </tbody>
+  </table>
+</details>
+
+<details open>
+  <summary>Task 4 — Characterization tests для chunk/store/search/lint (P2) · все шаги DONE</summary>
+  <table class="rpt-table">
+    <thead><tr><th>#</th><th>Шаг</th><th>Статус</th><th>Доказательство в diff</th></tr></thead>
+    <tbody>
+      <tr>
+        <td>1</td><td>test_store.py (quantize, dequantize, cosine)</td>
+        <td class="status-done">DONE</td>
+        <td>Создан; 4 теста</td>
+      </tr>
+      <tr>
+        <td>2</td><td>test_chunk.py (split на H2, overlap, no-heading)</td>
+        <td class="status-done">DONE</td>
+        <td>Создан; 3 теста</td>
+      </tr>
+      <tr>
+        <td>3</td><td>test_search.py (threshold, top_k)</td>
+        <td class="status-done">DONE</td>
+        <td>Создан; 2 теста</td>
+      </tr>
+      <tr>
+        <td>4</td><td>test_lint.py (broken/orphan/stale; P1 regression)</td>
+        <td class="status-done">DONE</td>
+        <td>Создан; 4 теста включая <code>test_code_fence_ref_not_broken</code></td>
+      </tr>
+      <tr>
+        <td>5</td><td>Весь suite green</td>
+        <td class="status-done">DONE</td>
+        <td>27/27 PASSED</td>
+      </tr>
+      <tr>
+        <td>6</td><td>Коммит</td>
+        <td class="status-done">DONE</td>
+        <td>Коммит <code>f548e3a7</code></td>
+      </tr>
+    </tbody>
+  </table>
+</details>
+
+<details open>
+  <summary>Task 5 — Config message (P7) + log schema (P6) · все шаги DONE</summary>
+  <table class="rpt-table">
+    <thead><tr><th>#</th><th>Шаг</th><th>Статус</th><th>Доказательство в diff</th></tr></thead>
+    <tbody>
+      <tr>
+        <td>1</td><td>Написать test_config.py</td>
+        <td class="status-done">DONE</td>
+        <td>Создан; 1 тест с assert на "IWIKI_LLM_BASE_URL", "IWIKI_LLM_KEY", "environment variable"</td>
+      </tr>
+      <tr>
+        <td>2–4</td><td>failing → fix config.py → passing</td>
+        <td class="status-done">DONE</td>
+        <td><code>config.py</code>: сообщение содержит "must be set as environment variables"</td>
+      </tr>
+      <tr>
+        <td>5</td><td>Добавить log-tolerance test в test_lint.py</td>
+        <td class="status-done">DONE</td>
+        <td>Добавлен <code>test_stale_ignores_legacy_and_malformed_log_records</code></td>
+      </tr>
+      <tr>
+        <td>6</td><td>Lint тесты PASS</td>
+        <td class="status-done">DONE</td>
+        <td>5/5 lint-тестов PASSED</td>
+      </tr>
+      <tr>
+        <td>7</td><td>Документировать canonical log schema в обоих SKILL.md</td>
+        <td class="status-done">DONE</td>
+        <td><code>iwiki-init/SKILL.md</code> и <code>iwiki-ingest/SKILL.md</code> обновлены: добавлен абзац про <code>{op, source, page, date}</code></td>
+      </tr>
+      <tr>
+        <td>8</td><td>Коммит</td>
+        <td class="status-done">DONE</td>
+        <td>Коммит <code>560a3b63</code></td>
+      </tr>
+    </tbody>
+  </table>
+</details>
+
+<details open>
+  <summary>Task 6 — Content fixes + documentation refresh (P3, P4) · 1 PARTIAL (rescoped)</summary>
+  <table class="rpt-table">
+    <thead><tr><th>#</th><th>Шаг</th><th>Статус</th><th>Доказательство в diff</th></tr></thead>
+    <tbody>
+      <tr>
+        <td>1</td><td>Re-ingest launcher.md и langfuse-capture.md</td>
+        <td class="status-rs">RESCOPED</td>
+        <td>Намеренно пропущен: mtime-based stale в свежем git worktree ненадёжен (checkout сбросил mtime)</td>
+      </tr>
+      <tr>
+        <td>2</td><td>Найти host page для [[html-report]] по related</td>
+        <td class="status-done">DONE</td>
+        <td>Выбрана <code>docs/wiki/architecture.md</code></td>
+      </tr>
+      <tr>
+        <td>3</td><td>Добавить [[html-report]] ссылку в host page</td>
+        <td class="status-done">DONE</td>
+        <td><code>architecture.md</code>: добавлена строка "See also: [[command]], [[launcher]], [[iwiki]], [[html-report]]"; <code>orphans=[]</code></td>
+      </tr>
+      <tr>
+        <td>4</td><td>Обновить docs/wiki/iwiki.md (Phase B изменения)</td>
+        <td class="status-done">DONE</td>
+        <td><code>iwiki.md</code>: описаны code-aware parsing, embed retry, related hardening, stderr warning</td>
+      </tr>
+      <tr>
+        <td>5</td><td>Re-index + lint</td>
+        <td class="status-part">PARTIAL</td>
+        <td>Lint выполнен: <code>broken=[], orphans=[]</code>. Re-index пропущен (реальные API-вызовы, rescoped)</td>
+      </tr>
+      <tr>
+        <td>6</td><td>Полный suite</td>
+        <td class="status-done">DONE</td>
+        <td>27/27 PASSED</td>
+      </tr>
+      <tr>
+        <td>7</td><td>Bump plugin version 0.5.5 → 0.6.0</td>
+        <td class="status-done">DONE</td>
+        <td><code>plugin.json</code>: <code>"version": "0.6.0"</code></td>
+      </tr>
+      <tr>
+        <td>8</td><td>Коммит</td>
+        <td class="status-done">DONE</td>
+        <td>Коммит <code>2181c9e0</code></td>
+      </tr>
+    </tbody>
+  </table>
+</details>
+
+<!-- ═══ Findings ═══ -->
+<h2>Findings</h2>
+
+<div class="note-warn">
+  <strong>[WARNING] Task 6, Step 5 — Re-index пропущен (частичное выполнение)</strong><br>
+  <p><strong>Plan:</strong> Запустить <code>python3 -m iwiki_engine --wiki-dir docs/wiki index</code>, затем <code>lint</code>; ожидается clean stale list.</p>
+  <p><strong>Diff:</strong> Re-index не запущен (нет изменений в <code>index.jsonl</code>). Lint запущен — <code>broken=[], orphans=[]</code>. Stale по-прежнему показывает 5 страниц (launcher.md, langfuse-capture.md, nvm.md, sandbox.md, config.md) — worktree-артефакт (checkout сбросил mtime), не ошибка кода.</p>
+  <p><strong>Fix options:</strong></p>
+  <ol>
+    <li>Запустить re-index вручную в окружении с <code>IWIKI_LLM_*</code>.</li>
+    <li>Признать приемлемым — stale-детектор корректен, поведение — следствие git worktree, не баг реализации.</li>
+  </ol>
+</div>
+
+<div class="note-warn">
+  <strong>[WARNING] Избыточный коммит: <code>c930252a style(iwiki): remove dead import os in related.py</code></strong><br>
+  <p><strong>Plan:</strong> Явного шага на удаление <code>import os</code> нет.</p>
+  <p><strong>Diff:</strong> Удаление мёртвого импорта — побочный эффект исправления Task 3 Step 3. Безвредно; план допускает clean-up собственного мусора (CLAUDE.md: "Remove imports/variables/functions YOUR changes made unused").</p>
+  <p><strong>Fix options:</strong></p>
+  <ol>
+    <li>Принять как есть — изменение корректно и соответствует правилам.</li>
+    <li>В будущем объединять такие clean-up коммиты с основным fix-коммитом.</li>
+  </ol>
+</div>
+
+<!-- ═══ Intent / Spec Coverage ═══ -->
+<h2>Покрытие Intent / Spec</h2>
+
+<h3>Desired Outcomes (intent) — 6/7 покрыто</h3>
+<div class="prog-wrap"><div class="prog-bar" style="width:85%"></div></div>
+<table class="rpt-table">
+  <thead><tr><th>Outcome</th><th>Статус</th><th>Примечание</th></tr></thead>
+  <tbody>
+    <tr><td><code>/iwiki-ingest</code> создаёт/обновляет страницы</td><td class="status-done">DONE</td><td>Task 6: iwiki.md и architecture.md обновлены</td></tr>
+    <tr><td><code>/iwiki-query</code> возвращает ответ + ссылки</td><td class="status-na">N/A</td><td>Не изменялся в Phase B (Phase A)</td></tr>
+    <tr><td>Embedding search по смыслу; related sections</td><td class="status-done">DONE</td><td>Task 2: embed retry; Task 3: related hardening</td></tr>
+    <tr><td>lat.md удалён из зависимостей</td><td class="status-na">N/A</td><td>Phase A (уже выполнено до этого плана)</td></tr>
+    <tr><td><code>/iwiki-lint</code> — отчёт по документации</td><td class="status-done">DONE</td><td><code>broken=[], orphans=[]</code> после исправлений</td></tr>
+    <tr><td>Wiki-страницы с [[...]]-ссылками</td><td class="status-done">DONE</td><td>architecture.md обновлена с корректными [[refs]]</td></tr>
+    <tr><td>(stretch) Dependency graph</td><td class="status-na">N/A</td><td>Out of scope в Phase B</td></tr>
+  </tbody>
+</table>
+
+<h3>Spec Success Criteria (§7) — 6/7 покрыто (1 rescoped)</h3>
+<div class="prog-wrap"><div class="prog-bar" style="width:86%"></div></div>
+<table class="rpt-table">
+  <thead><tr><th>Критерий</th><th>Статус</th><th>Примечание</th></tr></thead>
+  <tbody>
+    <tr><td>lint: нет false-positive broken refs</td><td class="status-done">DONE</td><td><code>broken=[]</code> ✓</td></tr>
+    <tr><td>html-report.md не orphan</td><td class="status-done">DONE</td><td><code>orphans=[]</code> ✓</td></tr>
+    <tr><td>pytest green + B1 code-fence case + store/chunk/search/lint</td><td class="status-done">DONE</td><td>27/27 PASSED ✓</td></tr>
+    <tr><td>embed.py retry path покрыт тестом</td><td class="status-done">DONE</td><td>test_embed.py: 3 теста ✓</td></tr>
+    <tr><td>config.py называет IWIKI_LLM_BASE_URL и IWIKI_LLM_KEY</td><td class="status-done">DONE</td><td>Верифицировано test_config.py ✓</td></tr>
+    <tr><td>log.jsonl canonical schema задокументирована</td><td class="status-done">DONE</td><td>Оба SKILL.md обновлены ✓</td></tr>
+    <tr><td>launcher.md и langfuse-capture.md не stale после re-ingest</td><td class="status-rs">RESCOPED</td><td>Пропущен: mtime-based stale в worktree — артефакт среды</td></tr>
+  </tbody>
+</table>
+
+<!-- ═══ Excess Changes ═══ -->
+<h2>Избыточные изменения (Excess)</h2>
+<table class="rpt-table">
+  <thead><tr><th>Файл / коммит</th><th>Тип</th><th>Оценка</th></tr></thead>
+  <tbody>
+    <tr>
+      <td><code>c930252a</code> — <code>related.py</code>: удалён <code>import os</code></td>
+      <td><span class="badge badge-warn">WARNING</span></td>
+      <td>Безвредно — собственный dead-code clean-up согласно правилам CLAUDE.md. Можно объединить с основным fix-коммитом.</td>
+    </tr>
+  </tbody>
+</table>
+
+<!-- ═══ Test suite result ═══ -->
+<h2>Итоги тестового suite</h2>
+<div class="note-ok">
+  <strong>27/27 тестов PASSED · 0 failures · 0 errors</strong><br>
+  <code>uv run --project plugin/iwiki/engine pytest plugin/iwiki/engine/tests -v</code> — время: 0.05s
+</div>
+<table class="rpt-table">
+  <thead><tr><th>Файл</th><th>Тестов</th><th>Покрывает</th></tr></thead>
+  <tbody>
+    <tr><td><code>test_links.py</code></td><td>5</td><td>P1: code-aware parsing (B1)</td></tr>
+    <tr><td><code>test_embed.py</code></td><td>3</td><td>P5: retry backoff (B3)</td></tr>
+    <tr><td><code>test_related.py</code></td><td>2</td><td>P5: unreadable file skip (B3)</td></tr>
+    <tr><td><code>test_iwiki_common.py</code></td><td>2</td><td>P5: stderr warning on corrupt state (B3)</td></tr>
+    <tr><td><code>test_store.py</code></td><td>4</td><td>quantize/dequantize/cosine (B2)</td></tr>
+    <tr><td><code>test_chunk.py</code></td><td>3</td><td>chunk_markdown (B2)</td></tr>
+    <tr><td><code>test_search.py</code></td><td>2</td><td>threshold/top_k (B2)</td></tr>
+    <tr><td><code>test_lint.py</code></td><td>5</td><td>broken/orphan/stale + tolerance (B2, P1 regression)</td></tr>
+    <tr><td><code>test_config.py</code></td><td>1</td><td>config error message (P7, B4)</td></tr>
+  </tbody>
+</table>
+
+<!-- ═══ Lint state ═══ -->
+<h2>Состояние lint</h2>
+<table class="rpt-table">
+  <thead><tr><th>Категория</th><th>Результат</th><th>Примечание</th></tr></thead>
+  <tbody>
+    <tr><td><code>broken</code> (ложные [[refs]])</td><td class="status-done">[] — чисто</td><td>P1 исправлен: bash <code>[[ ]]</code> игнорируется</td></tr>
+    <tr><td><code>orphans</code> (страницы без входящих ссылок)</td><td class="status-done">[] — чисто</td><td>html-report.md теперь связана через architecture.md</td></tr>
+    <tr><td><code>stale</code> (страницы отстают от источника)</td><td class="status-part">5 страниц</td><td>Worktree-артефакт: checkout сбросил mtime. Rescoped (ожидаемо)</td></tr>
+  </tbody>
+</table>
+
+<!-- ═══ Summary ═══ -->
+<h2>Итоговая сводка</h2>
+<div class="counters">
+  <div class="counter-card crit">
+    <div class="num">0</div>
+    <div class="lbl">CRITICAL</div>
+  </div>
+  <div class="counter-card warn">
+    <div class="num">2</div>
+    <div class="lbl">WARNING</div>
+  </div>
+  <div class="counter-card ok">
+    <div class="num">0</div>
+    <div class="lbl">INFO</div>
+  </div>
+</div>
+
+<div class="verdict-ok">
+  <div class="v-icon">✅</div>
+  <div class="v-text">
+    <strong>Вердикт: OK</strong><br>
+    Нет MISSING-шагов. Нет CRITICAL findings. Один PARTIAL-шаг (re-index) обоснованно rescoped контроллером как worktree-артефакт среды, а не ошибка реализации. Все spec §7 Success Criteria выполнены или rescoped. Тестовый suite зелёный (27/27). Код-aware парсинг, retry backoff, graph/session hardening, canonical log schema и config error — все задачи Phase B выполнены.
+  </div>
+</div>
+
+<p class="sub" style="margin-top:2rem; border-top:1px solid var(--border); padding-top:1rem;">
+  Body hash плана: <code>82f6bc2121fd7241</code> &nbsp;·&nbsp;
+  Сгенерировано: 2026-06-22 &nbsp;·&nbsp;
+  Chain: <code>intent → spec → plan</code>
+</p>
+
+</main>
+</body>
+</html>

--- a/docs/wiki/architecture.md
+++ b/docs/wiki/architecture.md
@@ -80,3 +80,5 @@ The isolated environment lives in `.nvm-isolated/` and provides a self-contained
 ## Configuration File
 
 The credentials/config file is `.claude_config` (formerly `.claude_proxy_credentials` — auto-migrated on first run). `init_environment()` sets `CREDENTIALS_FILE` to this path; Phase 15 reads it with `grep` regex patterns to load persistent flags (`USE_PII_PROXY`, `MICRO_VM_ENABLED`, `NO_ATTRIBUTION_HEADER`, `USE_CHROME`, `CLAUDE_CODE_SKIP_PERMISSIONS`) before argument parsing, so CLI flags can override them. The file is chmod 600 and excluded from git. See [[proxy#Credentials File]] for the full variable reference.
+
+See also: [[command]], [[launcher]], [[iwiki]], [[html-report]]

--- a/docs/wiki/iwiki.md
+++ b/docs/wiki/iwiki.md
@@ -25,6 +25,9 @@ Bash integration that installs and detects the **iwiki documentation-graph engin
 - Runs `uv run --project "$(_iwiki_engine_dir)" python3 -m iwiki_engine "$@"`.
 - If uv is unresolved, prints `iwiki: uv not found; run ./iclaude.sh --install-iwiki` and returns 1.
 - Subcommands: `index | search | related | status | lint`. `status` and `lint` are **config-free** (no `IWIKI_LLM_*`, no embedding call) — they dispatch before config load. `lint` reports `docs/wiki/` health (broken links, orphans, stale pages) as a JSON object and is a clean no-op (`{"wiki_present": false}`, exit 0) when the project has no wiki, so iwiki never errors in a project that does not use it. The `/iwiki-lint` skill calls this subcommand instead of composing shell.
+- **Code-aware link parsing**: the link parser that `lint` and `related` use ignores `[[...]]` tokens inside Markdown fenced code blocks and inline code spans, so shell `[[ ... ]]` test syntax in documentation never produces false broken-link reports.
+- **Embedding retry**: `index` and `search` wrap embedding API calls with bounded exponential backoff (retries on timeout, connection errors, and HTTP 5xx); 4xx errors fail fast without retrying.
+- **`related` graph hardening**: BFS traversal skips pages whose files cannot be read, so a single unreadable file never aborts the entire related-docs walk.
 
 ## Plugin Registration
 
@@ -39,7 +42,7 @@ Bash integration that installs and detects the **iwiki documentation-graph engin
 
 ## Automation Hooks
 
-The plugin bundles four Claude Code hooks (declared in `plugin/iwiki/hooks/hooks.json`, run from `${CLAUDE_PLUGIN_ROOT}/hooks/`) that keep the wiki consulted and current with no manual `/iwiki-*` step. They share `iwiki_common.py` (engine/uv resolution, git diff, project chdir, and a per-session state file) and are all fail-soft and individually kill-switchable. A hook cannot run a slash command or LLM skill directly, so each either drives the engine CLI deterministically or injects a directive Claude acts on.
+The plugin bundles four Claude Code hooks (declared in `plugin/iwiki/hooks/hooks.json`, run from `${CLAUDE_PLUGIN_ROOT}/hooks/`) that keep the wiki consulted and current with no manual `/iwiki-*` step. They share `iwiki_common.py` (engine/uv resolution, git diff, project chdir, and a per-session state file) and are all fail-soft and individually kill-switchable. The shared session-state reader warns on stderr when the state file exists but cannot be decoded (e.g. truncated JSON), then proceeds with an empty state rather than silently discarding the error. A hook cannot run a slash command or LLM skill directly, so each either drives the engine CLI deterministically or injects a directive Claude acts on.
 
 Engine/uv resolution is layered and **`CLAUDE_PLUGIN_ROOT`-independent**: `engine_dir()` tries the plugin root (only set for hooks), then the in-repo `plugin/iwiki/engine`, then the **newest** cached plugin version (`engine_dir()` sorts the cache glob by version). The `/iwiki-*` skills' bash steps mirror the same fallback, because `CLAUDE_PLUGIN_ROOT` is *not* exported into the Bash tool — relying on it alone expands to `--project /engine` and fails, so the skills must resolve the engine themselves.
 

--- a/plugin/iwiki/.claude-plugin/plugin.json
+++ b/plugin/iwiki/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "iwiki",
   "description": "Embedding-based documentation agent: ingest sources into a docs/wiki/, semantic query, and lint. Self-contained replacement for lat.md.",
-  "version": "0.5.5",
+  "version": "0.6.0",
   "author": { "name": "ikeniborn" },
   "keywords": ["documentation", "embeddings", "wiki", "semantic-search", "knowledge-graph"],
   "license": "MIT"

--- a/plugin/iwiki/engine/iwiki_engine/config.py
+++ b/plugin/iwiki/engine/iwiki_engine/config.py
@@ -39,8 +39,8 @@ class Config:
         api_key = getenv(key_var, "").strip()
         if not base_url or not api_key:
             raise ConfigError(
-                f"{url_var} and {key_var} must be set "
-                "(add them to .claude_config). Halting."
+                f"{url_var} and {key_var} must be set as environment variables "
+                "(e.g. exported from .claude_config). Halting."
             )
         if base_url.endswith("/"):
             base_url = base_url[:-1]

--- a/plugin/iwiki/engine/iwiki_engine/embed.py
+++ b/plugin/iwiki/engine/iwiki_engine/embed.py
@@ -1,11 +1,26 @@
-"""OpenAI-compatible embeddings client. Batches inputs; respects HTTPS_PROXY."""
+"""OpenAI-compatible embeddings client. Batches inputs; respects HTTPS_PROXY.
+
+Transient backend failures (timeouts, connection errors, HTTP 5xx) are retried
+with bounded exponential backoff before surfacing as EmbedError.
+"""
 from __future__ import annotations
+import time
 import httpx
 from .config import Config
+
+_MAX_ATTEMPTS = 3
+_BACKOFF_BASE = 0.5  # seconds; doubled each retry
 
 
 class EmbedError(RuntimeError):
     """Raised when the embedding backend is unreachable or errors (stop rule)."""
+
+
+def _is_transient(exc: httpx.HTTPError) -> bool:
+    """Timeouts, connection/transport failures, and HTTP 5xx are worth retrying."""
+    if isinstance(exc, httpx.HTTPStatusError):
+        return exc.response.status_code >= 500
+    return isinstance(exc, httpx.TransportError)
 
 
 def embed_texts(cfg: Config, texts: list[str]) -> list[list[float]]:
@@ -17,10 +32,17 @@ def embed_texts(cfg: Config, texts: list[str]) -> list[list[float]]:
     if cfg.dimensions:
         payload["dimensions"] = cfg.dimensions
     headers = {"Authorization": f"Bearer {cfg.api_key}"}
-    try:
-        resp = httpx.post(url, json=payload, headers=headers, timeout=60.0)
-        resp.raise_for_status()
-    except httpx.HTTPError as e:
-        raise EmbedError(f"embedding backend unreachable: {e}") from e
-    data = resp.json().get("data", [])
-    return [row["embedding"] for row in sorted(data, key=lambda r: r["index"])]
+    last: httpx.HTTPError | None = None
+    for attempt in range(_MAX_ATTEMPTS):
+        try:
+            resp = httpx.post(url, json=payload, headers=headers, timeout=60.0)
+            resp.raise_for_status()
+            data = resp.json().get("data", [])
+            return [row["embedding"] for row in sorted(data, key=lambda r: r["index"])]
+        except httpx.HTTPError as e:
+            last = e
+            if attempt + 1 < _MAX_ATTEMPTS and _is_transient(e):
+                time.sleep(_BACKOFF_BASE * (2 ** attempt))
+                continue
+            break
+    raise EmbedError(f"embedding backend unreachable: {last}") from last

--- a/plugin/iwiki/engine/iwiki_engine/links.py
+++ b/plugin/iwiki/engine/iwiki_engine/links.py
@@ -1,13 +1,26 @@
-"""Parse [[target]] / [[target|alias]] wiki-links from markdown."""
+"""Parse [[target]] / [[target|alias]] wiki-links from markdown, ignoring code."""
 from __future__ import annotations
 import re
 
 _LINK = re.compile(r"\[\[([^\]|]+)(?:\|[^\]]*)?\]\]")
+# Fenced code: ``` or ~~~ opener, lazily to a matching closer on its own line.
+_FENCE = re.compile(r"^[ \t]*(```|~~~).*?^[ \t]*\1[ \t]*$", re.DOTALL | re.MULTILINE)
+# Inline code spans: `...`
+_INLINE = re.compile(r"`[^`]*`")
+
+
+def _strip_code(content: str) -> str:
+    """Drop fenced code blocks and inline code spans so [[...]] inside code
+    (e.g. bash `[[ $# -gt 0 ]]`) is not mistaken for a wiki-link."""
+    content = _FENCE.sub("", content)
+    content = _INLINE.sub("", content)
+    return content
 
 
 def parse_links(content: str) -> list[str]:
-    """Return the target part of every [[...]] link, de-duplicated, order-preserving."""
+    """Return the target part of every [[...]] link, de-duplicated, order-preserving.
+    Links inside Markdown code (fenced or inline) are ignored."""
     seen: dict[str, None] = {}
-    for m in _LINK.finditer(content):
+    for m in _LINK.finditer(_strip_code(content)):
         seen.setdefault(m.group(1).strip(), None)
     return list(seen)

--- a/plugin/iwiki/engine/iwiki_engine/related.py
+++ b/plugin/iwiki/engine/iwiki_engine/related.py
@@ -1,6 +1,5 @@
 """Related sections: vector neighbours, with a [[refs]] graph fallback."""
 from __future__ import annotations
-import os
 from .store import Record, dequantize, cosine
 from .links import parse_links
 

--- a/plugin/iwiki/engine/iwiki_engine/related.py
+++ b/plugin/iwiki/engine/iwiki_engine/related.py
@@ -24,9 +24,11 @@ def _graph_neighbours(target_file: str, depth: int) -> list[str]:
     for _ in range(max(0, depth)):
         nxt: list[str] = []
         for f in frontier:
-            if not os.path.exists(f):
+            try:
+                content = open(f, encoding="utf-8").read()
+            except OSError:
                 continue
-            for link in parse_links(open(f, encoding="utf-8").read()):
+            for link in parse_links(content):
                 base = link.split("#", 1)[0]
                 if base and base not in seen:
                     seen.add(base)

--- a/plugin/iwiki/engine/pyproject.toml
+++ b/plugin/iwiki/engine/pyproject.toml
@@ -8,6 +8,9 @@ dependencies = ["httpx>=0.27"]
 [project.scripts]
 iwiki-engine = "iwiki_engine.__main__:main"
 
+[dependency-groups]
+dev = ["pytest>=8"]
+
 [tool.ruff]
 line-length = 100
 

--- a/plugin/iwiki/engine/tests/test_chunk.py
+++ b/plugin/iwiki/engine/tests/test_chunk.py
@@ -1,0 +1,20 @@
+from iwiki_engine.chunk import chunk_markdown
+
+
+def test_splits_on_h2_headings():
+    md = "intro ignored\n\n## First\nbody one\n\n## Second\nbody two\n"
+    chunks = chunk_markdown("f.md", md, size=512, overlap=64)
+    assert [c.heading for c in chunks] == ["First", "Second"]
+    assert chunks[0].id == "f.md#First"
+
+
+def test_content_before_first_heading_ignored():
+    assert chunk_markdown("f.md", "preamble only, no headings", size=512, overlap=64) == []
+
+
+def test_long_section_splits_with_overlap_and_indexes():
+    body = " ".join(str(i) for i in range(20))
+    chunks = chunk_markdown("f.md", f"## H\n{body}\n", size=8, overlap=2)
+    assert len(chunks) > 1
+    assert all(c.heading == "H" for c in chunks)
+    assert [c.chunk for c in chunks] == list(range(len(chunks)))

--- a/plugin/iwiki/engine/tests/test_config.py
+++ b/plugin/iwiki/engine/tests/test_config.py
@@ -1,0 +1,13 @@
+import pytest
+from iwiki_engine.config import Config, ConfigError
+
+
+def test_missing_config_names_env_vars(monkeypatch):
+    monkeypatch.delenv("IWIKI_LLM_BASE_URL", raising=False)
+    monkeypatch.delenv("IWIKI_LLM_KEY", raising=False)
+    with pytest.raises(ConfigError) as ei:
+        Config.load()
+    msg = str(ei.value)
+    assert "IWIKI_LLM_BASE_URL" in msg
+    assert "IWIKI_LLM_KEY" in msg
+    assert "environment variable" in msg.lower()

--- a/plugin/iwiki/engine/tests/test_embed.py
+++ b/plugin/iwiki/engine/tests/test_embed.py
@@ -1,0 +1,67 @@
+import httpx
+import pytest
+from iwiki_engine import embed as embed_mod
+from iwiki_engine.embed import embed_texts, EmbedError
+from iwiki_engine.config import Config
+
+
+def _cfg():
+    return Config(base_url="http://x", api_key="k", embed_model="m", dimensions=0,
+                  chunk_size=512, chunk_overlap=64, top_k=8, score_threshold=0.2,
+                  graph_depth=2, include=[], exclude=[])
+
+
+class _Resp:
+    def __init__(self, data):
+        self._data = data
+
+    def raise_for_status(self):
+        pass
+
+    def json(self):
+        return {"data": self._data}
+
+
+def test_retries_transient_then_succeeds(monkeypatch):
+    calls = {"n": 0}
+
+    def fake_post(*a, **k):
+        calls["n"] += 1
+        if calls["n"] < 3:
+            raise httpx.ConnectError("boom")
+        return _Resp([{"index": 0, "embedding": [0.1, 0.2]}])
+
+    monkeypatch.setattr(embed_mod.httpx, "post", fake_post)
+    monkeypatch.setattr(embed_mod.time, "sleep", lambda s: None)
+    assert embed_texts(_cfg(), ["hello"]) == [[0.1, 0.2]]
+    assert calls["n"] == 3
+
+
+def test_gives_up_after_max_attempts(monkeypatch):
+    calls = {"n": 0}
+
+    def fake_post(*a, **k):
+        calls["n"] += 1
+        raise httpx.ConnectError("down")
+
+    monkeypatch.setattr(embed_mod.httpx, "post", fake_post)
+    monkeypatch.setattr(embed_mod.time, "sleep", lambda s: None)
+    with pytest.raises(EmbedError):
+        embed_texts(_cfg(), ["hello"])
+    assert calls["n"] == 3
+
+
+def test_4xx_not_retried(monkeypatch):
+    calls = {"n": 0}
+    req = httpx.Request("POST", "http://x/embeddings")
+
+    def fake_post(*a, **k):
+        calls["n"] += 1
+        resp = httpx.Response(400, request=req)
+        raise httpx.HTTPStatusError("bad", request=req, response=resp)
+
+    monkeypatch.setattr(embed_mod.httpx, "post", fake_post)
+    monkeypatch.setattr(embed_mod.time, "sleep", lambda s: None)
+    with pytest.raises(EmbedError):
+        embed_texts(_cfg(), ["hello"])
+    assert calls["n"] == 1

--- a/plugin/iwiki/engine/tests/test_iwiki_common.py
+++ b/plugin/iwiki/engine/tests/test_iwiki_common.py
@@ -1,0 +1,33 @@
+import contextlib
+import io
+import os
+import sys
+
+# iwiki_common lives in the plugin's hooks/ dir, not the engine package.
+_HOOKS = os.path.normpath(os.path.join(os.path.dirname(__file__), "..", "..", "hooks"))
+sys.path.insert(0, _HOOKS)
+import iwiki_common  # noqa: E402
+
+
+def test_read_session_warns_on_corrupt_file(tmp_path, monkeypatch):
+    state = tmp_path / "iwiki-session.json"
+    state.write_text("{not valid json", encoding="utf-8")
+    monkeypatch.setattr(iwiki_common, "session_path", lambda: str(state))
+    err = io.StringIO()
+    with contextlib.redirect_stderr(err):
+        out = iwiki_common.read_session()
+    # fail-soft preserved: defaults returned
+    assert out["session_id"] == ""
+    assert out["count"] == 0
+    # no longer silent
+    assert "iwiki" in err.getvalue().lower()
+
+
+def test_read_session_silent_when_absent(tmp_path, monkeypatch):
+    missing = tmp_path / "nope.json"
+    monkeypatch.setattr(iwiki_common, "session_path", lambda: str(missing))
+    err = io.StringIO()
+    with contextlib.redirect_stderr(err):
+        out = iwiki_common.read_session()
+    assert out["session_id"] == ""
+    assert err.getvalue() == ""   # absent state is normal — stay quiet

--- a/plugin/iwiki/engine/tests/test_links.py
+++ b/plugin/iwiki/engine/tests/test_links.py
@@ -1,0 +1,30 @@
+from iwiki_engine.links import parse_links
+
+
+def test_ignores_fenced_code_block():
+    md = (
+        "See [[real-page]] for details.\n\n"
+        "```bash\n"
+        "if [[ $# -gt 0 ]]; then echo hi; fi\n"
+        '[[ -d "$LIB_DIR/<name>" ]]\n'
+        "```\n"
+    )
+    assert parse_links(md) == ["real-page"]
+
+
+def test_ignores_inline_code():
+    md = "Use `[[ -d x ]]` in bash, but link to [[guide]] here."
+    assert parse_links(md) == ["guide"]
+
+
+def test_alias_form_returns_target():
+    assert parse_links("[[core|the core module]]") == ["core"]
+
+
+def test_dedup_preserves_order():
+    md = "[[a]] then [[b]] then [[a]] again, and [[c]]."
+    assert parse_links(md) == ["a", "b", "c"]
+
+
+def test_section_ref_target_kept_whole():
+    assert parse_links("[[nvm#Claude Binary Detection]]") == ["nvm#Claude Binary Detection"]

--- a/plugin/iwiki/engine/tests/test_lint.py
+++ b/plugin/iwiki/engine/tests/test_lint.py
@@ -1,0 +1,38 @@
+import os
+from iwiki_engine.lint import lint
+
+
+def _wiki(tmp_path, pages: dict) -> str:
+    wd = tmp_path / "wiki"
+    wd.mkdir()
+    for name, body in pages.items():
+        (wd / name).write_text(body, encoding="utf-8")
+    return str(wd)
+
+
+def test_absent_wiki_is_noop(tmp_path):
+    assert lint(str(tmp_path / "nope")) == {"wiki_present": False}
+
+
+def test_detects_broken_ref(tmp_path):
+    wd = _wiki(tmp_path, {"a.md": "## A\nlink to [[missing]] here\n"})
+    out = lint(wd)
+    assert any(b["ref"] == "missing" for b in out["broken"])
+
+
+def test_code_fence_ref_not_broken(tmp_path):
+    # page-level regression for P1: bash [[...]] in a fence is not a broken ref
+    wd = _wiki(tmp_path, {
+        "a.md": "## A\n```bash\nif [[ -d x ]]; then :; fi\n```\n[[b]]\n",
+        "b.md": "## B\nbody\n",
+    })
+    assert lint(wd)["broken"] == []
+
+
+def test_detects_orphan(tmp_path):
+    wd = _wiki(tmp_path, {"a.md": "## A\nno links\n", "b.md": "## B\nno links\n"})
+    out = lint(wd)
+    assert set(out["orphans"]) == {
+        os.path.normpath(os.path.join(wd, "a.md")),
+        os.path.normpath(os.path.join(wd, "b.md")),
+    }

--- a/plugin/iwiki/engine/tests/test_lint.py
+++ b/plugin/iwiki/engine/tests/test_lint.py
@@ -1,3 +1,4 @@
+import json
 import os
 from iwiki_engine.lint import lint
 
@@ -36,3 +37,15 @@ def test_detects_orphan(tmp_path):
         os.path.normpath(os.path.join(wd, "a.md")),
         os.path.normpath(os.path.join(wd, "b.md")),
     }
+
+
+def test_stale_ignores_legacy_and_malformed_log_records(tmp_path):
+    wd = _wiki(tmp_path, {"a.md": "## A\nbody\n"})
+    iwiki = os.path.join(wd, ".iwiki")
+    os.makedirs(iwiki, exist_ok=True)
+    with open(os.path.join(iwiki, "log.jsonl"), "w", encoding="utf-8") as fh:
+        fh.write(json.dumps({"op": "init", "scope": "x", "note": "legacy"}) + "\n")
+        fh.write("not json at all\n")
+    out = lint(wd)
+    assert out["wiki_present"] is True
+    assert out["stale"] == []   # records lacking source/page are tolerated, ignored

--- a/plugin/iwiki/engine/tests/test_related.py
+++ b/plugin/iwiki/engine/tests/test_related.py
@@ -1,0 +1,28 @@
+from iwiki_engine.store import Record, quantize
+from iwiki_engine.related import related, _graph_neighbours
+
+
+def _rec(id, file, vec):
+    scale, q = quantize(vec)
+    return Record(id=id, file=file, heading=id.split("#")[-1], chunk=0,
+                  hash="h", dim=len(vec), scale=scale, q=q)
+
+
+def test_vector_neighbours_ranked_and_self_excluded():
+    recs = [
+        _rec("a.md#A", "a.md", [1.0, 0.0]),
+        _rec("b.md#B", "b.md", [0.9, 0.1]),   # close to A
+        _rec("c.md#C", "c.md", [0.0, 1.0]),   # orthogonal to A
+    ]
+    out = related("a.md#A", recs, top_k=2, graph_depth=2)
+    ids = [d["id"] for d in out["vector"]]
+    assert ids[0] == "b.md#B"
+    assert "a.md#A" not in ids
+
+
+def test_graph_skips_unreadable_path(tmp_path):
+    # A path that exists but cannot be read as a file (a directory) must be
+    # skipped by the BFS, not raise IsADirectoryError.
+    d = tmp_path / "weird.md"
+    d.mkdir()
+    assert _graph_neighbours(str(d), depth=1) == []

--- a/plugin/iwiki/engine/tests/test_search.py
+++ b/plugin/iwiki/engine/tests/test_search.py
@@ -1,0 +1,22 @@
+from iwiki_engine.store import Record, quantize
+from iwiki_engine.search import search
+
+
+def _rec(id, vec):
+    scale, q = quantize(vec)
+    return Record(id=id, file=id.split("#")[0], heading="H", chunk=0,
+                  hash="h", dim=len(vec), scale=scale, q=q)
+
+
+def test_threshold_filters_low_scores():
+    recs = [_rec("a.md#A", [1.0, 0.0]), _rec("b.md#B", [0.0, 1.0])]
+    out = search([1.0, 0.0], recs, top_k=10, threshold=0.5)
+    assert [d["id"] for d in out] == ["a.md#A"]   # B is orthogonal → filtered
+
+
+def test_top_k_limits_and_orders_by_score():
+    recs = [_rec("a.md#A", [1.0, 0.0]),
+            _rec("b.md#B", [0.9, 0.1]),
+            _rec("c.md#C", [0.8, 0.2])]
+    out = search([1.0, 0.0], recs, top_k=2, threshold=0.0)
+    assert [d["id"] for d in out] == ["a.md#A", "b.md#B"]

--- a/plugin/iwiki/engine/tests/test_store.py
+++ b/plugin/iwiki/engine/tests/test_store.py
@@ -1,0 +1,22 @@
+from iwiki_engine.store import quantize, dequantize, cosine
+
+
+def test_quantize_dequantize_roundtrip():
+    vec = [0.1, -0.5, 0.9, -1.0, 0.0]
+    scale, q = quantize(vec)
+    out = dequantize(scale, q)
+    assert all(abs(a - b) <= scale for a, b in zip(vec, out))
+
+
+def test_quantize_zero_vector():
+    scale, q = quantize([0.0, 0.0, 0.0])
+    assert q == [0, 0, 0]
+    assert scale == 1.0
+
+
+def test_cosine_identical_is_one():
+    assert abs(cosine([1.0, 2.0, 3.0], [1.0, 2.0, 3.0]) - 1.0) < 1e-9
+
+
+def test_cosine_zero_vector_is_zero():
+    assert cosine([0.0, 0.0], [1.0, 1.0]) == 0.0

--- a/plugin/iwiki/engine/uv.lock
+++ b/plugin/iwiki/engine/uv.lock
@@ -25,6 +25,15 @@ wheels = [
 ]
 
 [[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
 name = "h11"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -71,6 +80,15 @@ wheels = [
 ]
 
 [[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
 name = "iwiki-engine"
 version = "0.1.0"
 source = { editable = "." }
@@ -78,8 +96,59 @@ dependencies = [
     { name = "httpx" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+]
+
 [package.metadata]
 requires-dist = [{ name = "httpx", specifier = ">=0.27" }]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pytest", specifier = ">=8" }]
+
+[[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
+]
 
 [[package]]
 name = "typing-extensions"

--- a/plugin/iwiki/hooks/iwiki_common.py
+++ b/plugin/iwiki/hooks/iwiki_common.py
@@ -19,6 +19,7 @@ import json
 import os
 import shutil
 import subprocess
+import sys
 
 WIKI_DIR = "docs/wiki"
 INDEX_REL = os.path.join(WIKI_DIR, ".iwiki", "index.jsonl")
@@ -255,8 +256,10 @@ def read_session() -> dict:
             data = json.load(f)
         if isinstance(data, dict):
             out.update({k: data[k] for k in _SESSION_DEFAULT if k in data})
-    except Exception:
-        pass
+    except FileNotFoundError:
+        pass  # first run: no state yet — expected, stay silent
+    except Exception as e:
+        print(f"iwiki: ignoring unreadable session state ({e})", file=sys.stderr)
     return out
 
 

--- a/plugin/iwiki/skills/iwiki-ingest/SKILL.md
+++ b/plugin/iwiki/skills/iwiki-ingest/SKILL.md
@@ -46,6 +46,9 @@ You do NOT need iclaude's `lib/` — only the plugin and `IWIKI_LLM_*` config.
    printf '{"op":"ingest","source":"<src>","page":"<page>","date":"<YYYY-MM-DD>"}\n' \
      >> docs/wiki/.iwiki/log.jsonl
    ```
+   Canonical log record: `{op, source, page, date}` (`note` optional). Use exactly
+   these keys — `lint`'s stale check reads `source`/`page` and ignores records
+   missing them. Do not introduce alternative keys (e.g. `scope`).
 6. Report which page changed and the index size (warn if over the 8 MB cap).
 
 ## Stop rule

--- a/plugin/iwiki/skills/iwiki-init/SKILL.md
+++ b/plugin/iwiki/skills/iwiki-init/SKILL.md
@@ -62,6 +62,9 @@ indexes everything. Works in any project — the engine ships with this plugin
    printf '{"op":"init","source":"<src>","page":"<page>","date":"<YYYY-MM-DD>"}\n' \
      >> docs/wiki/.iwiki/log.jsonl
    ```
+   Canonical log record: `{op, source, page, date}` (`note` optional). Use exactly
+   these keys — `lint`'s stale check reads `source`/`page` and ignores records
+   missing them. Do not introduce alternative keys (e.g. `scope`).
 
 6. **Lint + summarize.** Invoke the `iwiki:iwiki-lint` skill (or run the checks)
    and report: pages created, chunk count, index size, and any gaps (source areas


### PR DESCRIPTION
## Summary

Phase B of the iwiki plugin evaluation+improvement effort (spec1). Empirical evaluation (Phase A) found the engine search strong (8/8 top-1 correct) but surfaced concrete defects; this branch fixes them, adds the engine's first test suite, and hardens fail-soft paths. No search-behavior changes.

Spec: `docs/superpowers/specs/2026-06-22-iwiki-evaluation-improvements-design.md`
Plan: `docs/superpowers/plans/2026-06-22-iwiki-evaluation-improvements.md`

## Changes

- **P1 — code-aware link parsing** (`links.py`): `parse_links` now ignores `[[...]]` inside Markdown code fences / inline code, so shell `[[ ... ]]` test syntax is no longer reported as broken refs (`lint`) or polluting the `related` graph BFS.
- **P5 — embedding retry** (`embed.py`): transient backend failures (timeouts, connection/transport errors, HTTP 5xx) retried with bounded exponential backoff (≤3 attempts); 4xx and other errors fail fast; `EmbedError` contract preserved.
- **P5 — hardening**: `related._graph_neighbours` skips files raising `OSError`; `iwiki_common.read_session` warns on stderr for a corrupt state file (silent only for `FileNotFoundError`), still fail-soft.
- **P2 — engine test suite**: new offline `pytest` suite (27 tests) covering links/embed/related/iwiki_common/store/chunk/search/lint/config; `pytest` added as a **dev-only** dependency group (runtime stays `httpx`-only).
- **P7/P6**: missing-config error names `IWIKI_LLM_BASE_URL`/`IWIKI_LLM_KEY` + "environment variable"; canonical log schema `{op, source, page, date}` documented in both skills.
- **P4 + docs**: html-report orphan fixed (incoming `[[html-report]]` ref in `architecture.md`); `iwiki.md` refreshed for the behavioral changes; plugin version 0.5.5 → 0.6.0.

## Verification

- `uv run --project plugin/iwiki/engine pytest plugin/iwiki/engine/tests` → **27/27 passing**, pristine.
- `lint` on the live wiki → `broken: []`, `orphans: []` (the two bash false-positives are gone).
- Per-task two-stage review (spec + quality) on every task; final whole-branch review: **ready to merge**, no Critical/Important findings.
- `result_check: verdict OK` (`docs/superpowers/reports/results/2026-06-22-iwiki-evaluation-improvements-result-check.html`).

## Deliberately deferred (not in this PR)

- Re-ingesting `launcher.md`/`langfuse-capture.md` for "stale" (P3) and re-running `index`: `lint`'s stale check is mtime-based and unreliable in a fresh git worktree (checkout resets mtimes → spurious entries); re-index makes real API calls and churns a soon-redone index. Tracked for a main-tree doc pass.
- Phase C (decouple from iclaude + publish standalone to the official marketplace) — future spec2; this PR includes only a blocker pointer in the spec.

## Minor follow-ups (non-blocking, from review)

- Add an HTTP-5xx retry test (the `status>=500` branch of `_is_transient` is covered by inspection only).
- Remove the cosmetic dead `continue` in the embed retry loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)