### PR TITLE
chore(iwiki): bump plugin 0.6.1 -> 0.6.2 to resync cached hooks

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
     {
       "name": "iwiki",
       "description": "Embedding-based documentation agent replacing lat.md.",
-      "version": "0.6.1",
+      "version": "0.6.2",
       "source": "./plugin/iwiki",
       "author": { "name": "ikeniborn" },
       "category": "documentation"

--- a/plugin/iwiki/.claude-plugin/plugin.json
+++ b/plugin/iwiki/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "iwiki",
   "description": "Embedding-based documentation agent: ingest sources into a docs/wiki/, semantic query, and lint. Self-contained replacement for lat.md.",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "author": { "name": "ikeniborn" },
   "keywords": ["documentation", "embeddings", "wiki", "semantic-search", "knowledge-graph"],
   "license": "MIT"


### PR DESCRIPTION
Routine version bump to verify the resync fix (PR #60) end-to-end and refresh the user-scope plugin cache.

- `plugin.json` and `marketplace.json` moved in lockstep `0.6.1 → 0.6.2` (guard `scripts/check-plugin-version-sync.sh` passes).

## Verification

`./iclaude.sh --install-iwiki` →
- `uv sync`: Resolved 14 / Checked 13.
- Refresh: **`Plugin "iwiki" updated from 0.6.1 to 0.6.2`** — proves a bump now actually triggers the cache refresh.
- `cache/.../0.6.2/` hooks complete: `iwiki-validate.py` + 5 fail-open guards + PreToolUse wired.
- `installed_plugins.json` → `0.6.2`, path `.../0.6.2`.
- Engine smoke: status 207 chunks / 24 files; lint 0 broken / 0 orphans.

🤖 Generated with [Claude Code](https://claude.com/claude-code)