### PR TITLE
feat(iwiki): port content-hash freshness from ai-wiki-plugin

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -4,4 +4,4 @@ One row per IDD→SDD chain `<topic>`. Upserted by the `check-*` commands.
 
 | Topic | Status | Intent | Spec | Plan | Result | Opened | Closed | Notes |
 |---|---|---|---|---|---|---|---|---|
-| iwiki-content-hash-freshness-port | in-progress | n/a | ✓ | – | – | 2026-06-30 | | Port content-hash freshness from ai-wiki-plugin into plugin/iwiki; spec opens the chain (no intent) |
+| iwiki-content-hash-freshness-port | in-progress | n/a | ✓ | ✓ | – | 2026-06-30 | | Port content-hash freshness from ai-wiki-plugin into plugin/iwiki; spec opens the chain (no intent) |

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1,0 +1,7 @@
+# Task Log
+
+One row per IDD→SDD chain `<topic>`. Upserted by the `check-*` commands.
+
+| Topic | Status | Intent | Spec | Plan | Result | Opened | Closed | Notes |
+|---|---|---|---|---|---|---|---|---|
+| iwiki-content-hash-freshness-port | in-progress | n/a | ✓ | – | – | 2026-06-30 | | Port content-hash freshness from ai-wiki-plugin into plugin/iwiki; spec opens the chain (no intent) |

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -4,4 +4,4 @@ One row per IDD→SDD chain `<topic>`. Upserted by the `check-*` commands.
 
 | Topic | Status | Intent | Spec | Plan | Result | Opened | Closed | Notes |
 |---|---|---|---|---|---|---|---|---|
-| iwiki-content-hash-freshness-port | in-progress | n/a | ✓ | ✓ | – | 2026-06-30 | | Port content-hash freshness from ai-wiki-plugin into plugin/iwiki; spec opens the chain (no intent) |
+| iwiki-content-hash-freshness-port | done | n/a | ✓ | ✓ | OK | 2026-06-30 | 2026-06-30 | Port content-hash freshness from ai-wiki-plugin into plugin/iwiki; spec opens the chain (no intent) |

--- a/docs/superpowers/plans/2026-06-30-iwiki-content-hash-freshness-port.md
+++ b/docs/superpowers/plans/2026-06-30-iwiki-content-hash-freshness-port.md
@@ -20,6 +20,10 @@ review:
     "Task 4: Full-suite verification": f77a4b2f2a23520e
     "Notes for the executor": a8f99912e0d5c75c
   findings: []
+result_check:
+  verdict: OK
+  plan_hash: af6f9cb06d18e442
+  last_run: 2026-06-30
 ---
 
 # iwiki Content-Hash Freshness Port — Implementation Plan

--- a/docs/superpowers/plans/2026-06-30-iwiki-content-hash-freshness-port.md
+++ b/docs/superpowers/plans/2026-06-30-iwiki-content-hash-freshness-port.md
@@ -1,3 +1,27 @@
+---
+chain:
+  intent: null
+  spec: docs/superpowers/specs/2026-06-30-iwiki-content-hash-freshness-port-design.md
+review:
+  plan_hash: af6f9cb06d18e442
+  spec_hash: 46590f57fe2de22d
+  last_run: 2026-06-30
+  phases:
+    structure:     { status: passed }
+    coverage:      { status: passed }
+    dependencies:  { status: passed }
+    verifiability: { status: passed }
+    consistency:   { status: passed }
+  section_hashes:
+    "Global Constraints": cd0c2ab82149be39
+    "Task 1: Engine lint — content-hash staleness": feffbf1d93b4b76c
+    "Task 2: Stop-hook — content-hash coverage": 9d143b4eba381e12
+    "Task 3: Skills — write `src_hash` into the ingest log": aa83a99dbad27ea1
+    "Task 4: Full-suite verification": f77a4b2f2a23520e
+    "Notes for the executor": a8f99912e0d5c75c
+  findings: []
+---
+
 # iwiki Content-Hash Freshness Port — Implementation Plan
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.

--- a/docs/superpowers/plans/2026-06-30-iwiki-content-hash-freshness-port.md
+++ b/docs/superpowers/plans/2026-06-30-iwiki-content-hash-freshness-port.md
@@ -1,0 +1,509 @@
+# iwiki Content-Hash Freshness Port — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Port content-addressed staleness detection (a `src_hash` log field + a hash-with-mtime-fallback freshness test) from the standalone `ai-wiki-plugin` into `iclaude/plugin/iwiki`, replacing the mtime-only staleness check.
+
+**Architecture:** Ingest/init skills record `sha256(source)[:16]` as `src_hash` in `docs/wiki/.iwiki/log.jsonl`. Two consumers — the engine lint (`_stale`) and the Stop-hook (`covered_sources`) — decide freshness via a shared predicate `_fresh(src, page, src_hash)`: compare by content hash when the record carries `src_hash` and the source is readable, else fall back to the existing `mtime(page) >= mtime(source)`. The predicate is implemented as exact mirrors in both files.
+
+**Tech Stack:** Python 3.12, `uv`-managed engine project (`plugin/iwiki/engine`), pytest, Markdown SKILL docs.
+
+## Global Constraints
+
+- Scope is **`plugin/iwiki` only** — touch nothing outside it.
+- `src_hash` = `sha256(source raw bytes).hexdigest()[:16]` (16 hex chars). Use this exact definition everywhere.
+- `_fresh` in `engine/iwiki_engine/lint.py` and `hooks/iwiki_common.py` must be **exact mirrors** (same logic, same fallback).
+- **Backward compatible:** records without `src_hash` keep the mtime path. No migration, no backfill.
+- `covered_sources` stays the exact inverse of `lint._stale`.
+- **Keep iclaude-specific code/text unchanged:** the `plugin/iwiki/engine` engine-path candidates in `hooks/iwiki_common.py` and every `SKILL.md`; the `.claude_config` wording in `config.py`; the `lib/iwiki` / "iclaude" references in docstrings and skill prose. Do **not** port the standalone's path/text de-specializations, version bump, or `marketplace.json`.
+- Source of every ported block: `/home/ikeniborn/Documents/Project/ai-wiki-plugin` (v0.6.5).
+- Already on branch `dev-iwiki-content-hash` (based on `origin/dev`). Commit each task; do not push (push only on explicit user request).
+- Commit footer on every commit: `Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>`.
+
+---
+
+### Task 1: Engine lint — content-hash staleness
+
+**Files:**
+- Modify: `plugin/iwiki/engine/iwiki_engine/lint.py`
+- Test: `plugin/iwiki/engine/tests/test_lint.py`
+
+**Interfaces:**
+- Produces: `_src_hash(src: str) -> str | None`, `_fresh(src: str, page: str, src_hash: str | None) -> bool` (module-level in `lint.py`). `_stale` now reports a page iff `not _fresh(...)`.
+- Consumes: nothing from other tasks.
+
+Run all commands from the repo root `/home/ikeniborn/Documents/Project/iclaude`. The engine test command is:
+`uv run --project plugin/iwiki/engine pytest plugin/iwiki/engine/tests/<file> -v`
+
+- [ ] **Step 1: Add the failing tests**
+
+Append to `plugin/iwiki/engine/tests/test_lint.py`, and add `import hashlib` to the top of that file (it currently starts with `import json` / `import os`):
+
+```python
+import hashlib  # add to the existing import block at the top of the file
+```
+
+Append at the end of the file:
+
+```python
+def _h(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()[:16]
+
+
+def _wiki_with_log(tmp_path, page_body, src_body, src_hash=None):
+    """Wiki dir with one page, one source file, and a single ingest log record
+    (absolute paths). Returns (wiki_dir, src_path, page_path)."""
+    wd = tmp_path / "wiki"
+    wd.mkdir()
+    page = wd / "a.md"
+    page.write_text(page_body, encoding="utf-8")
+    src = tmp_path / "a.py"
+    src.write_text(src_body, encoding="utf-8")
+    iwiki = wd / ".iwiki"
+    iwiki.mkdir()
+    rec = {"op": "ingest", "source": str(src), "page": str(page)}
+    if src_hash is not None:
+        rec["src_hash"] = src_hash
+    (iwiki / "log.jsonl").write_text(json.dumps(rec) + "\n", encoding="utf-8")
+    return str(wd), str(src), str(page)
+
+
+def test_stale_hash_match_overrides_older_page_mtime(tmp_path):
+    # The cure case: page mtime OLDER than source, but src_hash matches the
+    # current source → NOT stale (kills git-reset / same-day false positives).
+    wd, src, page = _wiki_with_log(
+        tmp_path, "## A\nbody\n", "print('x')\n", src_hash=_h("print('x')\n"))
+    os.utime(src, (2000, 2000))
+    os.utime(page, (1000, 1000))
+    assert lint(wd)["stale"] == []
+
+
+def test_stale_hash_mismatch_is_stale_even_if_page_newer(tmp_path):
+    # Hash recorded for OLD content; source now differs → stale regardless of mtime.
+    wd, src, page = _wiki_with_log(
+        tmp_path, "## A\nbody\n", "new content\n", src_hash=_h("old content\n"))
+    os.utime(src, (1000, 1000))
+    os.utime(page, (2000, 2000))
+    assert any(s["source"] == src for s in lint(wd)["stale"])
+
+
+def test_stale_without_hash_uses_mtime(tmp_path):
+    # No src_hash in the record → unchanged mtime behaviour.
+    wd, src, page = _wiki_with_log(tmp_path, "## A\nbody\n", "x\n")
+    os.utime(src, (2000, 2000))
+    os.utime(page, (1000, 1000))
+    assert any(s["source"] == src for s in lint(wd)["stale"])
+    os.utime(page, (3000, 3000))
+    assert lint(wd)["stale"] == []
+
+
+def test_stale_hash_present_but_unreadable_falls_back_to_mtime(tmp_path, monkeypatch):
+    # src_hash present but source unreadable (_src_hash → None) → mtime path.
+    import iwiki_engine.lint as lintmod
+    wd, src, page = _wiki_with_log(
+        tmp_path, "## A\nbody\n", "x\n", src_hash="deadbeefdeadbeef")
+    monkeypatch.setattr(lintmod, "_src_hash", lambda p: None)
+    os.utime(src, (2000, 2000))
+    os.utime(page, (1000, 1000))
+    assert any(s["source"] == src for s in lint(wd)["stale"])
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `uv run --project plugin/iwiki/engine pytest plugin/iwiki/engine/tests/test_lint.py -v`
+Expected: FAIL. `test_stale_hash_match_overrides_older_page_mtime` fails (mtime-only `_stale` still flags it), and `test_stale_hash_present_but_unreadable_falls_back_to_mtime` errors at `monkeypatch.setattr(lintmod, "_src_hash", ...)` because `_src_hash` does not exist yet.
+
+- [ ] **Step 3: Add `import hashlib` to lint.py**
+
+In `plugin/iwiki/engine/iwiki_engine/lint.py`, the import block is `import glob` / `import json` / `import os` / `import re`. Add `import hashlib` right after `import glob`:
+
+```python
+import glob
+import hashlib
+import json
+import os
+import re
+```
+
+- [ ] **Step 4: Add the `_src_hash` and `_fresh` helpers**
+
+Insert these two functions immediately **before** `def _stale(wiki_dir: str) -> list[dict]:`:
+
+```python
+def _src_hash(src: str) -> str | None:
+    """sha256 of the source's raw bytes, first 16 hex chars. None when the file
+    cannot be read — the caller then falls back to the mtime comparison."""
+    try:
+        with open(src, "rb") as fh:
+            return hashlib.sha256(fh.read()).hexdigest()[:16]
+    except OSError:
+        return None
+
+
+def _fresh(src: str, page: str, src_hash: str | None) -> bool:
+    """Is `page` current for `src`? Content-addressed when the log record
+    carries `src_hash` and the source is readable; otherwise the page is fresh
+    iff it is at least as new as the source by mtime (the prior behaviour)."""
+    if src_hash:
+        cur = _src_hash(src)
+        if cur is not None:
+            return cur == src_hash
+    return os.path.getmtime(page) >= os.path.getmtime(src)
+```
+
+- [ ] **Step 5: Update `_stale` to use `_fresh`**
+
+In `_stale`, update the docstring and the comparison. Change the docstring line:
+
+```python
+    """Pages whose source changed after the last ingest, via .iwiki/log.jsonl
+    (content-hash with mtime fallback; no git). Deduped by page, first hit wins."""
+```
+
+And change the comparison inside the `try:` block from:
+
+```python
+                if os.path.getmtime(src) > os.path.getmtime(page):
+```
+
+to:
+
+```python
+                if not _fresh(src, page, rec.get("src_hash")):
+```
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+Run: `uv run --project plugin/iwiki/engine pytest plugin/iwiki/engine/tests/test_lint.py -v`
+Expected: PASS — all existing lint tests plus the 4 new ones.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add plugin/iwiki/engine/iwiki_engine/lint.py plugin/iwiki/engine/tests/test_lint.py
+git commit -m "feat(iwiki): content-hash staleness in engine lint
+
+Record-driven src_hash freshness with mtime fallback, replacing the
+mtime-only _stale check. Backward compatible: records without src_hash
+keep the prior behaviour.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Stop-hook — content-hash coverage
+
+**Files:**
+- Modify: `plugin/iwiki/hooks/iwiki_common.py`
+- Test: `plugin/iwiki/engine/tests/test_iwiki_common.py`
+
+**Interfaces:**
+- Consumes: the `_fresh` semantics defined in Task 1 (mirrored here, not imported).
+- Produces: `_src_hash`, `_fresh`, `_ingest_records()` (generator yielding well-formed log records oldest-first) in `iwiki_common.py`. `source_page_map()` and `covered_sources()` keep their existing signatures and now read via `_ingest_records()` and `_fresh`.
+
+`hashlib` is already imported in `iwiki_common.py` — do not add it there. The hook tests live in the engine test suite and `import iwiki_common`.
+
+- [ ] **Step 1: Add the failing tests**
+
+In `plugin/iwiki/engine/tests/test_iwiki_common.py`, add `import hashlib` to the top import block (the file currently starts with `import contextlib` / `import io` / `import json as _json` / `import os` / `import sys`). The helpers `_setup_wiki(tmp_path, monkeypatch)` and `_write_log(log, records)` already exist in this file. Append at the end:
+
+```python
+def test_covered_sources_hash_match_overrides_mtime(tmp_path, monkeypatch):
+    # Cure case mirror of the engine test: page OLDER by mtime but hash matches
+    # → still covered.
+    log = _setup_wiki(tmp_path, monkeypatch)
+    (tmp_path / "a.py").write_text("x", encoding="utf-8")
+    (tmp_path / "docs" / "wiki" / "a.md").write_text("y", encoding="utf-8")
+    h = hashlib.sha256(b"x").hexdigest()[:16]
+    _write_log(log, [
+        {"op": "ingest", "source": "a.py", "page": "docs/wiki/a.md", "src_hash": h}])
+    os.utime("a.py", (3000, 3000))
+    os.utime("docs/wiki/a.md", (1000, 1000))
+    assert iwiki_common.covered_sources() == {"a.py"}
+
+
+def test_covered_sources_hash_mismatch_not_covered(tmp_path, monkeypatch):
+    # Page NEWER by mtime but hash differs → not covered.
+    log = _setup_wiki(tmp_path, monkeypatch)
+    (tmp_path / "a.py").write_text("x", encoding="utf-8")
+    (tmp_path / "docs" / "wiki" / "a.md").write_text("y", encoding="utf-8")
+    _write_log(log, [
+        {"op": "ingest", "source": "a.py", "page": "docs/wiki/a.md",
+         "src_hash": "0000000000000000"}])
+    os.utime("a.py", (1000, 1000))
+    os.utime("docs/wiki/a.md", (2000, 2000))
+    assert iwiki_common.covered_sources() == set()
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `uv run --project plugin/iwiki/engine pytest plugin/iwiki/engine/tests/test_iwiki_common.py -v`
+Expected: FAIL. `test_covered_sources_hash_match_overrides_mtime` fails (mtime-only `covered_sources` does not mark the older page covered) and `test_covered_sources_hash_mismatch_not_covered` fails (mtime-only marks the newer page covered).
+
+- [ ] **Step 3: Replace `source_page_map` and `covered_sources`**
+
+In `plugin/iwiki/hooks/iwiki_common.py`, replace the entire existing `source_page_map` function **and** the existing `covered_sources` function (they are adjacent) with the following. Add the three new helpers above them. Note `json.loads` (matching this file's existing `import json`), and that the `plugin/iwiki/engine` path resolution elsewhere in the file is **not** touched.
+
+Replace this exact block:
+
+```python
+def source_page_map() -> dict[str, str]:
+    """Map each source → its most recent wiki page from the ingest log
+    (docs/wiki/.iwiki/log.jsonl). Last record wins per source. Same record
+    predicate as the engine's lint._stale: any record carrying both `source`
+    and `page` counts (no `op` filter). Fail-soft → {}."""
+    out: dict[str, str] = {}
+    try:
+        with open(LOG_REL, encoding="utf-8") as f:
+            lines = f.read().splitlines()
+    except Exception:
+        return out
+    for line in lines:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            rec = json.loads(line)
+            if not isinstance(rec, dict):
+                continue
+        except Exception:
+            continue
+        src, page = rec.get("source"), rec.get("page")
+        if src and page:
+            out[src] = page          # last record wins
+    return out
+
+
+def covered_sources() -> set[str]:
+    """Sources already covered by a fresh wiki page: the source's most recent
+    page (per source_page_map) exists on disk and is at least as new as the
+    source. The freshness test mtime(page) >= mtime(source) is the exact
+    inverse of lint._stale, so for any (source, page) pair this calls "covered"
+    exactly the pairs lint would not call stale. Fail-soft → empty set (subtract
+    nothing → safe over-nag, bounded by MAX_ASK)."""
+    covered: set[str] = set()
+    for src, page in source_page_map().items():
+        try:
+            if os.path.isfile(src) and os.path.isfile(page) \
+                    and os.path.getmtime(page) >= os.path.getmtime(src):
+                covered.add(src)
+        except Exception:
+            continue
+    return covered
+```
+
+with this:
+
+```python
+def _src_hash(src: str) -> str | None:
+    """sha256 of the source's raw bytes, first 16 hex chars; None if unreadable.
+    Mirror of engine lint._src_hash."""
+    try:
+        with open(src, "rb") as fh:
+            return hashlib.sha256(fh.read()).hexdigest()[:16]
+    except OSError:
+        return None
+
+
+def _fresh(src: str, page: str, src_hash: str | None) -> bool:
+    """Is `page` current for `src`? Content-addressed when the record carries
+    `src_hash` and the source is readable; else mtime (page >= source). The
+    exact mirror of engine lint._fresh."""
+    if src_hash:
+        cur = _src_hash(src)
+        if cur is not None:
+            return cur == src_hash
+    return os.path.getmtime(page) >= os.path.getmtime(src)
+
+
+def _ingest_records():
+    """Yield each well-formed log record (a dict carrying both `source` and
+    `page`) from docs/wiki/.iwiki/log.jsonl, oldest first. Fail-soft → nothing."""
+    try:
+        with open(LOG_REL, encoding="utf-8") as f:
+            lines = f.read().splitlines()
+    except Exception:
+        return
+    for line in lines:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            rec = json.loads(line)
+            if not isinstance(rec, dict):
+                continue
+        except Exception:
+            continue
+        if rec.get("source") and rec.get("page"):
+            yield rec
+
+
+def source_page_map() -> dict[str, str]:
+    """Map each source → its most recent wiki page from the ingest log
+    (docs/wiki/.iwiki/log.jsonl). Last record wins per source. A record counts
+    when it carries both `source` and `page`. Fail-soft → {}."""
+    out: dict[str, str] = {}
+    for rec in _ingest_records():
+        out[rec["source"]] = rec["page"]          # last record wins
+    return out
+
+
+def covered_sources() -> set[str]:
+    """Sources already covered by a fresh wiki page: the source's most recent
+    log record names a page that exists on disk and is fresh for the source
+    (hash match when the record has `src_hash`, else page mtime >= source).
+    The freshness test is the exact inverse of lint._stale. Fail-soft → empty
+    set (subtract nothing → safe over-nag, bounded by MAX_ASK)."""
+    latest: dict[str, dict] = {}
+    for rec in _ingest_records():
+        latest[rec["source"]] = rec               # last record wins
+    covered: set[str] = set()
+    for src, rec in latest.items():
+        page = rec["page"]
+        try:
+            if os.path.isfile(src) and os.path.isfile(page) \
+                    and _fresh(src, page, rec.get("src_hash")):
+                covered.add(src)
+        except Exception:
+            continue
+    return covered
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `uv run --project plugin/iwiki/engine pytest plugin/iwiki/engine/tests/test_iwiki_common.py -v`
+Expected: PASS — all existing hook tests plus the 2 new ones.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add plugin/iwiki/hooks/iwiki_common.py plugin/iwiki/engine/tests/test_iwiki_common.py
+git commit -m "feat(iwiki): content-hash coverage in Stop-hook
+
+Mirror the engine's src_hash/_fresh freshness in covered_sources via a
+shared _ingest_records reader. Keeps the plugin/iwiki/engine path
+resolution and iclaude docstrings unchanged.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Skills — write `src_hash` into the ingest log
+
+**Files:**
+- Modify: `plugin/iwiki/skills/iwiki-ingest/SKILL.md`
+- Modify: `plugin/iwiki/skills/iwiki-init/SKILL.md`
+
+**Interfaces:**
+- Produces the `src_hash` field that Task 1/Task 2 consume. No code, no test; verified by `grep`. Do **not** touch the `ENG="plugin/iwiki/engine"` fallback lines or any "iclaude" wording in these files.
+
+- [ ] **Step 1: Update the iwiki-ingest log step**
+
+In `plugin/iwiki/skills/iwiki-ingest/SKILL.md`, replace this exact block (step 5):
+
+````markdown
+   ```bash
+   printf '{"op":"ingest","source":"<src>","page":"<page>","date":"<YYYY-MM-DD>"}\n' \
+     >> docs/wiki/.iwiki/log.jsonl
+   ```
+   Canonical log record: `{op, source, page, date}` (`note` optional). Use exactly
+   these keys — `lint`'s stale check reads `source`/`page` and ignores records
+   missing them. Do not introduce alternative keys (e.g. `scope`).
+````
+
+with:
+
+````markdown
+   ```bash
+   printf '{"op":"ingest","source":"<src>","page":"<page>","date":"<YYYY-MM-DD>","src_hash":"%s"}\n' \
+     "$(sha256sum '<src>' | cut -c1-16)" \
+     >> docs/wiki/.iwiki/log.jsonl
+   ```
+   Substitute `<src>` (same path in both the `source` field and the `sha256sum`
+   argument), `<page>`, and `<YYYY-MM-DD>` literally; `src_hash` is filled by the
+   shell. Canonical log record: `{op, source, page, date, src_hash}` (`note`
+   optional). `src_hash` is the sha256 of the source's raw bytes, first 16 hex
+   chars — `lint`'s stale check prefers it over mtime. Use exactly these keys;
+   do not introduce alternatives (e.g. `scope`).
+````
+
+- [ ] **Step 2: Update the iwiki-init log step**
+
+In `plugin/iwiki/skills/iwiki-init/SKILL.md`, replace this exact block (step 5):
+
+````markdown
+   ```bash
+   printf '{"op":"init","source":"<src>","page":"<page>","date":"<YYYY-MM-DD>"}\n' \
+     >> docs/wiki/.iwiki/log.jsonl
+   ```
+   Canonical log record: `{op, source, page, date}` (`note` optional). Use exactly
+   these keys — `lint`'s stale check reads `source`/`page` and ignores records
+   missing them. Do not introduce alternative keys (e.g. `scope`).
+````
+
+with:
+
+````markdown
+   ```bash
+   printf '{"op":"init","source":"<src>","page":"<page>","date":"<YYYY-MM-DD>","src_hash":"%s"}\n' \
+     "$(sha256sum '<src>' | cut -c1-16)" \
+     >> docs/wiki/.iwiki/log.jsonl
+   ```
+   Substitute `<src>` (same path in both the `source` field and the `sha256sum`
+   argument), `<page>`, and `<YYYY-MM-DD>` literally; `src_hash` is filled by the
+   shell. Canonical log record: `{op, source, page, date, src_hash}` (`note`
+   optional). `src_hash` is the sha256 of the source's raw bytes, first 16 hex
+   chars — `lint`'s stale check prefers it over mtime. Use exactly these keys;
+   do not introduce alternatives (e.g. `scope`).
+````
+
+- [ ] **Step 3: Verify the edits landed and nothing else moved**
+
+```bash
+grep -n 'src_hash' plugin/iwiki/skills/iwiki-ingest/SKILL.md plugin/iwiki/skills/iwiki-init/SKILL.md
+grep -n 'ENG="plugin/iwiki/engine"' plugin/iwiki/skills/iwiki-ingest/SKILL.md plugin/iwiki/skills/iwiki-init/SKILL.md
+```
+Expected: first grep shows the new `src_hash` printf + note lines in both files; second grep still shows the `plugin/iwiki/engine` fallback intact in both.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add plugin/iwiki/skills/iwiki-ingest/SKILL.md plugin/iwiki/skills/iwiki-init/SKILL.md
+git commit -m "docs(iwiki): record src_hash in ingest/init log steps
+
+ingest and init skills now append src_hash (sha256[:16]) to log.jsonl so
+lint and the Stop-hook can compare by content hash. Engine-path fallbacks
+and iclaude references unchanged.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Full-suite verification
+
+**Files:** none modified — verification only.
+
+- [ ] **Step 1: Run the full engine test suite**
+
+Run: `uv run --project plugin/iwiki/engine pytest plugin/iwiki/engine/tests -q`
+Expected: all tests pass, including the 6 new ones (4 in `test_lint.py`, 2 in `test_iwiki_common.py`).
+
+- [ ] **Step 2: Guard against class-2 regressions**
+
+```bash
+grep -rn 'plugin/iwiki/engine' plugin/iwiki/hooks/iwiki_common.py plugin/iwiki/skills/*/SKILL.md
+grep -rn 'src_hash' plugin/iwiki/engine/iwiki_engine/lint.py plugin/iwiki/hooks/iwiki_common.py plugin/iwiki/skills/iwiki-ingest/SKILL.md plugin/iwiki/skills/iwiki-init/SKILL.md
+grep -n '.claude_config' plugin/iwiki/engine/iwiki_engine/config.py
+```
+Expected: first grep — `plugin/iwiki/engine` still present in the hook and all skills (not regressed to `engine`); second grep — `src_hash` present in lint, hook, and both skills; third grep — `.claude_config` wording still in `config.py`.
+
+---
+
+## Notes for the executor
+
+- The `<src>`/`<page>`/`<YYYY-MM-DD>` tokens inside the SKILL.md `printf` blocks are intentional placeholders in the *runtime* skill instructions — leave them literal; they are not plan placeholders.
+- After all tasks, the chain advances via `check-plan` (IDD gate). Expect a `/check-plan` run on this plan before execution proceeds, mirroring how `/check-spec` gated the spec.
+- **Post-merge (outside this plan's `plugin/iwiki`-only scope):** the iclaude "Keep Docs Current" policy applies because engine/hook behaviour changed. After merge, refresh `docs/wiki/` via the `iwiki:iwiki-ingest` skill for `plugin/iwiki/engine/iwiki_engine/lint.py` and `plugin/iwiki/hooks/iwiki_common.py`, then run `iwiki:iwiki-lint`. Tracked separately from this spec's scope.

--- a/docs/superpowers/reports/iwiki-content-hash-freshness-port-results.html
+++ b/docs/superpowers/reports/iwiki-content-hash-freshness-port-results.html
@@ -1,0 +1,286 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Цепочка IDD→SDD: iwiki-content-hash-freshness-port</title>
+<style>
+:root{
+  --bg:#0f1419; --surface:#1a212b; --surface2:#222b38; --border:#33404f;
+  --text:#e6edf3; --muted:#8b98a8; --accent:#4ea1ff; --accent2:#7ee787;
+  --ok:#3fb950; --warn:#d29922; --crit:#f85149; --shadow:rgba(0,0,0,.45);
+}
+body:has(#theme-toggle:checked){
+  --bg:#f6f8fa; --surface:#ffffff; --surface2:#eef2f6; --border:#d0d7de;
+  --text:#1f2328; --muted:#5b6470; --accent:#0969da; --accent2:#1a7f37;
+  --ok:#1a7f37; --warn:#9a6700; --crit:#cf222e; --shadow:rgba(140,149,159,.25);
+}
+*{box-sizing:border-box;}
+body{
+  margin:0; font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;
+  background:var(--bg); color:var(--text); line-height:1.55; transition:background .2s,color .2s;
+}
+header{
+  display:flex; align-items:center; gap:1rem; padding:1.2rem 1.6rem;
+  border-bottom:1px solid var(--border); background:var(--surface);
+}
+header h1{font-size:1.15rem; margin:0; font-weight:600;}
+.theme-btn{
+  cursor:pointer; user-select:none; font-size:1.1rem; padding:.35rem .6rem;
+  border:1px solid var(--border); border-radius:8px; background:var(--surface2);
+}
+main{max-width:1100px; margin:0 auto; padding:1.4rem 1.6rem 4rem;}
+h2{font-size:1.05rem; margin:1.8rem 0 .8rem; padding-bottom:.3rem; border-bottom:1px solid var(--border);}
+h3{font-size:.95rem; margin:1.4rem 0 .6rem; color:var(--accent);}
+table{width:100%; border-collapse:collapse; margin:.6rem 0 1.2rem; font-size:.86rem;}
+th,td{text-align:left; padding:.5rem .65rem; border:1px solid var(--border); vertical-align:top;}
+th{background:var(--surface2); font-weight:600;}
+tr:nth-child(even) td{background:var(--surface);}
+code{font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace; font-size:.82em;
+  background:var(--surface2); padding:.1rem .35rem; border-radius:4px;}
+.note{background:var(--surface); border-left:3px solid var(--accent); padding:.7rem 1rem;
+  border-radius:0 6px 6px 0; margin:1rem 0; color:var(--muted);}
+.badge{display:inline-block; padding:.12rem .55rem; border-radius:999px; font-size:.75rem;
+  font-weight:600; border:1px solid;}
+.badge.ok{color:var(--ok); border-color:var(--ok);}
+.badge.warn{color:var(--warn); border-color:var(--warn);}
+.badge.crit{color:var(--crit); border-color:var(--crit);}
+.badge.muted{color:var(--muted); border-color:var(--border);}
+.chain-tabs{display:flex; gap:.3rem; padding:0 1.6rem; margin-top:1rem; flex-wrap:wrap;}
+.chain-tabs label{cursor:pointer; padding:.45rem 1rem; border:1px solid var(--border);
+  border-bottom:none; border-radius:8px 8px 0 0; background:var(--surface); color:var(--muted); font-size:.9rem;}
+.tab-pane{display:none; animation:fade .25s ease;}
+@keyframes fade{from{opacity:0; transform:translateY(4px);} to{opacity:1; transform:none;}}
+body:has(#tab-intent:checked) #pane-intent,
+body:has(#tab-spec:checked)   #pane-spec,
+body:has(#tab-plan:checked)   #pane-plan,
+body:has(#tab-result:checked) #pane-result{display:block;}
+body:has(#tab-intent:checked) label[for="tab-intent"],
+body:has(#tab-spec:checked)   label[for="tab-spec"],
+body:has(#tab-plan:checked)   label[for="tab-plan"],
+body:has(#tab-result:checked) label[for="tab-result"]{color:var(--accent); border-color:var(--accent); font-weight:600; background:var(--surface2);}
+
+/* Block/flow diagram */
+.flow{display:flex; flex-direction:column; gap:.9rem; margin:1rem 0;}
+.flow-row{display:flex; gap:.9rem; align-items:stretch; flex-wrap:wrap; justify-content:center;}
+.node{background:var(--surface2); border:1px solid var(--border); border-radius:10px;
+  padding:.7rem .9rem; min-width:160px; box-shadow:0 2px 6px var(--shadow);}
+.node .nt{font-weight:600; font-size:.85rem;}
+.node .nd{font-size:.76rem; color:var(--muted); margin-top:.25rem;}
+.node.acc{border-color:var(--accent);}
+.node.ok{border-color:var(--ok);}
+.arrow{align-self:center; color:var(--accent); font-size:1.3rem;}
+svg{max-width:100%; height:auto; display:block; margin:1rem auto; background:var(--surface);
+  border:1px solid var(--border); border-radius:10px;}
+.summary-grid{display:flex; gap:1rem; flex-wrap:wrap; margin:1rem 0;}
+.metric{background:var(--surface2); border:1px solid var(--border); border-radius:10px;
+  padding:.8rem 1.1rem; min-width:140px;}
+.metric .v{font-size:1.5rem; font-weight:700;}
+.metric .l{font-size:.78rem; color:var(--muted);}
+</style>
+</head>
+<body>
+<input type="checkbox" id="theme-toggle" hidden>
+<input type="radio" name="chain-tab" id="tab-intent" class="tab-radio" hidden>
+<input type="radio" name="chain-tab" id="tab-spec"   class="tab-radio" hidden checked>
+<input type="radio" name="chain-tab" id="tab-plan"   class="tab-radio" hidden>
+<input type="radio" name="chain-tab" id="tab-result" class="tab-radio" hidden>
+<header>
+  <label for="theme-toggle" class="theme-btn" title="Переключить тему">🌙 / ☀️</label>
+  <h1>Цепочка IDD→SDD — <code>iwiki-content-hash-freshness-port</code></h1>
+</header>
+<nav class="chain-tabs">
+  <label for="tab-intent">Intent</label>
+  <label for="tab-spec">Spec</label>
+  <label for="tab-plan">Plan</label>
+  <label for="tab-result">Result</label>
+</nav>
+<main>
+<!-- TAB:intent START -->
+<section class="tab-pane" id="pane-intent">
+  <p class="note">Этап ещё не проверён. Intent-документ для этой цепочки отсутствует — спецификация открывает цепочку (<code>Intent: n/a</code>).</p>
+</section>
+<!-- TAB:intent END -->
+<!-- TAB:spec START -->
+<section class="tab-pane" id="pane-spec">
+
+  <h2>1. Резюме спецификации</h2>
+  <p>
+    <strong>Port content-hash freshness from <code>ai-wiki-plugin</code> into <code>plugin/iwiki</code></strong><br>
+    Дата: 2026-06-30 · Статус: approved (design) · Область: только <code>plugin/iwiki</code> ·
+    <code>spec_hash: 46590f57fe2de22d</code>
+  </p>
+
+  <h3>Требования (по секциям)</h3>
+  <table>
+    <thead><tr><th>Секция</th><th>Требование</th></tr></thead>
+    <tbody>
+      <tr><td>§Problem</td><td>Заменить mtime-детекцию устаревания на content-addressed (хеш содержимого источника); устранить ложные «stale» при <code>git reset/checkout</code>, правках в тот же день и копировании файлов.</td></tr>
+      <tr><td>§What ports</td><td>Портировать <strong>только класс 1</strong> (content-hash freshness). НЕ портировать класс 2 (de-specialization: путь движка <code>plugin/iwiki/engine→engine</code>, удаление <code>.claude_config</code>/<code>detect.sh</code>/iclaude-ссылок, sample в <code>test_chunk</code>). НЕ портировать класс 3 (distribution metadata: version bump <code>plugin.json</code>, <code>marketplace.json</code>).</td></tr>
+      <tr><td>§Log record</td><td>Записи ingest/init в <code>docs/wiki/.iwiki/log.jsonl</code> получают опциональный ключ <code>src_hash = sha256(raw bytes).hexdigest()[:16]</code>. Старые записи без ключа работают через mtime. Без миграции/бэкфилла.</td></tr>
+      <tr><td>§Freshness predicate</td><td>Инвариант <code>_fresh(src,page,src_hash)</code>: если <code>src_hash</code> задан И источник читаем → сравнение по хешу; иначе mtime (<code>page≥source</code>). Хелпер <code>_src_hash</code> возвращает <code>None</code> при <code>OSError</code>. Два call-site (<code>lint._stale</code> и <code>iwiki_common.covered_sources</code>) — точные зеркала: <code>_stale = not _fresh</code>, <code>covered = _fresh</code>.</td></tr>
+      <tr><td>§Backward/forward compat</td><td>Старые записи → mtime (идентично текущему). Нечитаемый источник при заданном <code>src_hash</code> → <code>None</code> → mtime fallback. Никогда не падает (fail-soft).</td></tr>
+      <tr><td>§Files changed</td><td>Гибридный подход. <em>copy wholesale</em>: <code>lint.py</code>, <code>test_lint.py</code> (+hashlib, +4 теста), <code>test_iwiki_common.py</code> (+hashlib, +2 теста). <em>surgical edit</em>: <code>hooks/iwiki_common.py</code> (add <code>_src_hash</code>/<code>_fresh</code>/<code>_ingest_records</code>, рефактор <code>source_page_map</code>+<code>covered_sources</code>, СОХРАНИТЬ docstring и кандидат <code>plugin/iwiki/engine</code>), <code>iwiki-ingest/SKILL.md</code> и <code>iwiki-init/SKILL.md</code> (step-5 пишет <code>src_hash</code> через <code>sha256sum|cut -c1-16</code>, СОХРАНИТЬ <code>ENG=plugin/iwiki/engine</code> fallback).</td></tr>
+      <tr><td>§Explicitly NOT touched</td><td><code>config.py</code>, <code>test_chunk.py</code>, docstring+<code>_engine_project</code> пути, skills engine-path fallbacks, <code>plugin.json</code>, <code>marketplace.json</code>, <code>README.md</code>.</td></tr>
+      <tr><td>§Verification</td><td>1) <code>pytest</code> зелёный, включая 6 новых тестов. 2) <code>grep plugin/iwiki/engine</code> в hook+skills — class-2 пути не регрессировали. 3) <code>grep -rn src_hash plugin/iwiki</code> — фича приземлилась в lint, hook, обоих скиллах.</td></tr>
+      <tr><td>§Behavioural checks</td><td>hash match + page mtime OLDER → fresh/covered; hash mismatch + page mtime NEWER → stale/not covered; нет <code>src_hash</code> → mtime behaviour; <code>src_hash</code> есть, но источник нечитаем → mtime fallback.</td></tr>
+      <tr><td>§Out of scope</td><td><code>lib/iwiki</code> (<code>detect.sh</code>/<code>install.sh</code>), любые изменения вне <code>plugin/iwiki</code>, version bump и marketplace metadata.</td></tr>
+      <tr><td>§Workflow note</td><td>База ветки (<code>dev</code> vs <code>master</code>), PR target, <code>wk-dev-*</code> worktree — решения пользователя на kickoff, не предполагаются.</td></tr>
+    </tbody>
+  </table>
+
+  <h3>Success Criteria</h3>
+  <table>
+    <thead><tr><th>#</th><th>Критерий приёмки</th></tr></thead>
+    <tbody>
+      <tr><td>SC1</td><td><code>pytest</code> зелёный; 6 новых тестов проходят (4 в <code>test_lint.py</code>, 2 в <code>test_iwiki_common.py</code>).</td></tr>
+      <tr><td>SC2</td><td>class-2 пути (<code>plugin/iwiki/engine</code>) НЕ регрессировали в <code>engine</code>.</td></tr>
+      <tr><td>SC3</td><td><code>src_hash</code> присутствует в <code>lint.py</code>, <code>iwiki_common.py</code>, <code>iwiki-ingest/SKILL.md</code>, <code>iwiki-init/SKILL.md</code>.</td></tr>
+      <tr><td>SC4</td><td>Обратная совместимость: старые записи без <code>src_hash</code> → идентичное mtime-поведение; fail-soft при нечитаемом источнике.</td></tr>
+    </tbody>
+  </table>
+
+  <h2>2. Схемы решения и зависимостей</h2>
+
+  <h3>Схема решения — компоненты и поток данных</h3>
+  <div class="flow">
+    <div class="flow-row">
+      <div class="node acc"><div class="nt">Источник (source file)</div><div class="nd">сырые байты</div></div>
+      <div class="arrow">→</div>
+      <div class="node"><div class="nt">_src_hash(src)</div><div class="nd">sha256(bytes)[:16]; None при OSError</div></div>
+      <div class="arrow">→</div>
+      <div class="node ok"><div class="nt">log.jsonl запись</div><div class="nd">опциональный ключ src_hash</div></div>
+    </div>
+    <div class="flow-row">
+      <div class="node"><div class="nt">skills iwiki-ingest / iwiki-init</div><div class="nd">step-5 пишут запись с src_hash</div></div>
+      <div class="arrow">↑ производят</div>
+    </div>
+    <div class="flow-row">
+      <div class="node acc"><div class="nt">_fresh(src,page,src_hash)</div><div class="nd">ветка hash → сравнение; иначе ветка mtime (page≥source)</div></div>
+    </div>
+    <div class="flow-row">
+      <div class="node"><div class="nt">lint.py · _stale</div><div class="nd">= not _fresh(...) → stale-report</div></div>
+      <div class="arrow">←  зеркала  →</div>
+      <div class="node"><div class="nt">iwiki_common.py · covered_sources</div><div class="nd">= _fresh(...) → Stop-hook nag</div></div>
+    </div>
+    <div class="flow-row">
+      <div class="node ok"><div class="nt">test_lint.py (4)</div><div class="nd">обе ветки + fallback</div></div>
+      <div class="node ok"><div class="nt">test_iwiki_common.py (2)</div><div class="nd">covered_sources</div></div>
+    </div>
+  </div>
+  <p class="note">Ключевой инвариант <code>_fresh</code> + хелпер <code>_src_hash</code> реализованы как <strong>два точных зеркала</strong> в <code>lint.py</code> и <code>iwiki_common.py</code> — общий контракт, без общего модуля.</p>
+
+  <h3>Граф зависимостей (A→B = A зависит от B)</h3>
+  <svg viewBox="0 0 760 420" role="img" aria-label="Граф зависимостей требований">
+    <defs>
+      <marker id="arr" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+        <path d="M0,0 L10,5 L0,10 z" fill="#4ea1ff"/>
+      </marker>
+      <filter id="ds" x="-20%" y="-20%" width="140%" height="140%">
+        <feDropShadow dx="0" dy="1" stdDeviation="1.5" flood-color="#000" flood-opacity="0.35"/>
+      </filter>
+    </defs>
+    <style>
+      .gn rect{fill:#222b38; stroke:#33404f; rx:8;}
+      .gn.acc rect{stroke:#4ea1ff;}
+      .gn.ok rect{stroke:#3fb950;}
+      .gn text{fill:#e6edf3; font:600 11px sans-serif;}
+      .ge{stroke:#4ea1ff; stroke-width:1.6; fill:none; marker-end:url(#arr);}
+      body:has(#theme-toggle:checked) .gn rect{fill:#eef2f6; stroke:#d0d7de;}
+      body:has(#theme-toggle:checked) .gn.acc rect{stroke:#0969da;}
+      body:has(#theme-toggle:checked) .gn.ok rect{stroke:#1a7f37;}
+      body:has(#theme-toggle:checked) .gn text{fill:#1f2328;}
+      body:has(#theme-toggle:checked) .ge{stroke:#0969da;}
+    </style>
+    <!-- edges -->
+    <path class="ge" d="M170,70 L300,120"/>            <!-- _stale -> _fresh -->
+    <path class="ge" d="M170,170 L300,140"/>           <!-- covered_sources -> _fresh -->
+    <path class="ge" d="M420,130 L540,80"/>            <!-- _fresh -> _src_hash -->
+    <path class="ge" d="M420,135 L540,190"/>           <!-- _fresh -> log record -->
+    <path class="ge" d="M640,90 L680,150 L640,205" />  <!-- _src_hash -> source bytes (curve) -->
+    <path class="ge" d="M610,225 L470,300"/>           <!-- log record -> skills -->
+    <path class="ge" d="M150,300 L300,150"/>           <!-- backward-compat -> _fresh -->
+    <path class="ge" d="M170,360 L150,150"/>           <!-- test_lint -> _fresh region -->
+    <!-- nodes -->
+    <g class="gn acc"><rect x="40" y="50" width="130" height="38"/><text x="58" y="73">_stale (lint.py)</text></g>
+    <g class="gn acc"><rect x="20" y="152" width="170" height="38"/><text x="32" y="175">covered_sources (hook)</text></g>
+    <g class="gn ok"><rect x="300" y="112" width="120" height="40"/><text x="330" y="137">_fresh</text></g>
+    <g class="gn"><rect x="540" y="58" width="100" height="38"/><text x="560" y="81">_src_hash</text></g>
+    <g class="gn"><rect x="612" y="190" width="120" height="38"/><text x="624" y="213">source bytes</text></g>
+    <g class="gn"><rect x="540" y="170" width="120" height="38" style="display:none"/></g>
+    <g class="gn"><rect x="500" y="170" width="150" height="40"/><text x="512" y="195">log record (src_hash)</text></g>
+    <g class="gn"><rect x="360" y="290" width="160" height="40"/><text x="372" y="315">skills ingest/init</text></g>
+    <g class="gn"><rect x="40" y="290" width="150" height="38"/><text x="52" y="313">backward-compat (mtime)</text></g>
+    <g class="gn ok"><rect x="40" y="345" width="150" height="38"/><text x="52" y="368">tests (lint + common)</text></g>
+  </svg>
+  <p class="note">Циклов в графе <strong>нет</strong>. <code>lint._fresh</code> и <code>iwiki_common._fresh</code> — два независимых узла с общим контрактом (зеркала, не цикл).</p>
+
+  <h3>Карта покрытия (задача → требования спецификации)</h3>
+  <table>
+    <thead><tr><th>Задача</th><th>Описание</th><th>Покрывающие требования</th></tr></thead>
+    <tbody>
+      <tr><td>T1</td><td>copy <code>lint.py</code> (add <code>_src_hash</code>/<code>_fresh</code>; <code>_stale</code> uses <code>_fresh</code>)</td><td>§Freshness predicate, §Files changed</td></tr>
+      <tr><td>T2</td><td>copy <code>test_lint.py</code> (+hashlib, 4 теста)</td><td>§Behavioural checks, §Verification(1)</td></tr>
+      <tr><td>T3</td><td>copy <code>test_iwiki_common.py</code> (+hashlib, 2 теста)</td><td>§Behavioural checks, §Verification(1)</td></tr>
+      <tr><td>T4</td><td>surgical edit <code>iwiki_common.py</code> (helpers + рефактор, СОХРАНИТЬ class-2)</td><td>§Freshness predicate, §Files changed, §Verification(2)</td></tr>
+      <tr><td>T5</td><td>surgical edit <code>iwiki-ingest/SKILL.md</code> (step-5 src_hash, СОХРАНИТЬ ENG fallback)</td><td>§Log record, §Files changed, §Verification(3)</td></tr>
+      <tr><td>T6</td><td>surgical edit <code>iwiki-init/SKILL.md</code> (step-5 src_hash, СОХРАНИТЬ ENG fallback)</td><td>§Log record, §Files changed, §Verification(3)</td></tr>
+      <tr><td>T7</td><td>НЕ трогать class-2/class-3</td><td>§Explicitly NOT touched, §Out of scope</td></tr>
+    </tbody>
+  </table>
+
+  <h2>3. Результаты проверки</h2>
+
+  <h3>Фазы</h3>
+  <table>
+    <thead><tr><th>Фаза</th><th>Статус</th></tr></thead>
+    <tbody>
+      <tr><td>structure</td><td><span class="badge ok">passed</span></td></tr>
+      <tr><td>coverage</td><td><span class="badge ok">passed</span></td></tr>
+      <tr><td>clarity</td><td><span class="badge ok">passed</span></td></tr>
+      <tr><td>consistency</td><td><span class="badge ok">passed</span></td></tr>
+    </tbody>
+  </table>
+
+  <h3>Findings</h3>
+  <table>
+    <thead><tr><th>id</th><th>severity</th><th>section</th><th>fragment</th><th>text</th><th>fix</th><th>verdict</th></tr></thead>
+    <tbody>
+      <tr><td colspan="7" style="text-align:center; color:var(--muted);">Находок нет — <code>findings: []</code></td></tr>
+    </tbody>
+  </table>
+
+  <h3>Сводка</h3>
+  <div class="summary-grid">
+    <div class="metric"><div class="v" style="color:var(--crit)">0</div><div class="l">CRITICAL open</div></div>
+    <div class="metric"><div class="v" style="color:var(--warn)">0</div><div class="l">WARNING open</div></div>
+    <div class="metric"><div class="v" style="color:var(--ok)">OK</div><div class="l">Вердикт</div></div>
+  </div>
+
+  <h3>Цепочка</h3>
+  <p>
+    <span class="badge muted">intent: n/a</span> →
+    <span class="badge ok">spec: passed</span> →
+    <span class="badge muted">plan: —</span> →
+    <span class="badge muted">result: —</span>
+  </p>
+  <p class="note">
+    Intent-документ для топика <code>iwiki-content-hash-freshness-port</code> не найден — спецификация <strong>открывает цепочку</strong>.<br>
+    spec: <code>docs/superpowers/specs/2026-06-30-iwiki-content-hash-freshness-port-design.md</code> (review passed).
+  </p>
+
+</section>
+<!-- TAB:spec END -->
+<!-- TAB:plan START -->
+<section class="tab-pane" id="pane-plan">
+  <p class="note">Этап ещё не проверён.</p>
+</section>
+<!-- TAB:plan END -->
+<!-- TAB:result START -->
+<section class="tab-pane" id="pane-result">
+  <p class="note">Этап ещё не проверён.</p>
+</section>
+<!-- TAB:result END -->
+</main>
+</body>
+</html>

--- a/docs/superpowers/reports/iwiki-content-hash-freshness-port-results.html
+++ b/docs/superpowers/reports/iwiki-content-hash-freshness-port-results.html
@@ -83,8 +83,8 @@ svg{max-width:100%; height:auto; display:block; margin:1rem auto; background:var
 <input type="checkbox" id="theme-toggle" hidden>
 <input type="radio" name="chain-tab" id="tab-intent" class="tab-radio" hidden>
 <input type="radio" name="chain-tab" id="tab-spec"   class="tab-radio" hidden>
-<input type="radio" name="chain-tab" id="tab-plan"   class="tab-radio" hidden checked>
-<input type="radio" name="chain-tab" id="tab-result" class="tab-radio" hidden>
+<input type="radio" name="chain-tab" id="tab-plan"   class="tab-radio" hidden>
+<input type="radio" name="chain-tab" id="tab-result" class="tab-radio" hidden checked>
 <header>
   <label for="theme-toggle" class="theme-btn" title="Переключить тему">🌙 / ☀️</label>
   <h1>Цепочка IDD→SDD — <code>iwiki-content-hash-freshness-port</code></h1>
@@ -412,7 +412,167 @@ svg{max-width:100%; height:auto; display:block; margin:1rem auto; background:var
 <!-- TAB:plan END -->
 <!-- TAB:result START -->
 <section class="tab-pane" id="pane-result">
-  <p class="note">Этап ещё не проверён.</p>
+
+  <h2>Result Check — 2026-06-30</h2>
+
+  <h3>Документы</h3>
+  <table>
+    <thead><tr><th>Артефакт</th><th>Путь / значение</th></tr></thead>
+    <tbody>
+      <tr><td>План</td><td><code>docs/superpowers/plans/2026-06-30-iwiki-content-hash-freshness-port.md</code></td></tr>
+      <tr><td>Спека</td><td><code>docs/superpowers/specs/2026-06-30-iwiki-content-hash-freshness-port-design.md</code></td></tr>
+      <tr><td>Интент</td><td><span class="badge muted">отсутствует</span> — цепочка открывается спекой (<code>chain.intent: null</code>)</td></tr>
+      <tr><td>Diff base</td><td><code>git diff e86d87af..8113c5b8</code> — 6 файлов изменено</td></tr>
+      <tr><td>Коммиты</td><td>
+        <code>063ef619</code> feat(iwiki): content-hash staleness in engine lint<br>
+        <code>f70f1018</code> feat(iwiki): content-hash coverage in Stop-hook<br>
+        <code>8113c5b8</code> docs(iwiki): record src_hash in ingest/init log steps
+      </td></tr>
+    </tbody>
+  </table>
+
+  <h3>Покрытие шагов плана</h3>
+  <div class="summary-grid">
+    <div class="metric"><div class="v" style="color:var(--ok)">4</div><div class="l">DONE</div></div>
+    <div class="metric"><div class="v" style="color:var(--muted)">0</div><div class="l">PARTIAL</div></div>
+    <div class="metric"><div class="v" style="color:var(--crit)">0</div><div class="l">MISSING</div></div>
+    <div class="metric"><div class="v" style="color:var(--muted)">0</div><div class="l">EXCESS</div></div>
+  </div>
+
+  <table>
+    <thead><tr><th>Задача</th><th>Шаги</th><th>Файлы в diff</th><th>Статус</th><th>Коммит</th></tr></thead>
+    <tbody>
+      <tr>
+        <td>Task 1: Engine lint — content-hash staleness</td>
+        <td>1–7</td>
+        <td><code>lint.py</code>, <code>test_lint.py</code></td>
+        <td><span class="badge ok">DONE</span></td>
+        <td><code>063ef619</code></td>
+      </tr>
+      <tr>
+        <td>Task 2: Stop-hook — content-hash coverage</td>
+        <td>1–5</td>
+        <td><code>iwiki_common.py</code>, <code>test_iwiki_common.py</code></td>
+        <td><span class="badge ok">DONE</span></td>
+        <td><code>f70f1018</code></td>
+      </tr>
+      <tr>
+        <td>Task 3: Skills — write <code>src_hash</code> into the ingest log</td>
+        <td>1–4</td>
+        <td><code>iwiki-ingest/SKILL.md</code>, <code>iwiki-init/SKILL.md</code></td>
+        <td><span class="badge ok">DONE</span></td>
+        <td><code>8113c5b8</code></td>
+      </tr>
+      <tr>
+        <td>Task 4: Full-suite verification</td>
+        <td>1–2</td>
+        <td>— (верификация, нет изменений кода)</td>
+        <td><span class="badge ok">DONE</span></td>
+        <td><span class="badge muted">61/61 тестов</span></td>
+      </tr>
+    </tbody>
+  </table>
+
+  <h3>Детали по задачам</h3>
+
+  <table>
+    <thead><tr><th>Задача</th><th>Что реализовано (подтверждено diff'ом)</th></tr></thead>
+    <tbody>
+      <tr>
+        <td>T1 · <code>lint.py</code> + <code>test_lint.py</code></td>
+        <td>
+          <ul style="margin:0; padding-left:1.2rem">
+            <li><code>import hashlib</code> добавлен в <code>lint.py</code></li>
+            <li>Функции <code>_src_hash()</code> и <code>_fresh()</code> добавлены перед <code>_stale()</code></li>
+            <li>Docstring <code>_stale</code>: «mtime-based» → «content-hash with mtime fallback»</li>
+            <li>Сравнение: <code>os.path.getmtime(src) &gt; os.path.getmtime(page)</code> → <code>not _fresh(src, page, rec.get("src_hash"))</code></li>
+            <li><code>test_lint.py</code>: <code>import hashlib</code>, хелперы <code>_h</code> и <code>_wiki_with_log</code>, 4 новых теста</li>
+          </ul>
+        </td>
+      </tr>
+      <tr>
+        <td>T2 · <code>iwiki_common.py</code> + <code>test_iwiki_common.py</code></td>
+        <td>
+          <ul style="margin:0; padding-left:1.2rem">
+            <li>Добавлены <code>_src_hash()</code>, <code>_fresh()</code> — точные зеркала engine-версий</li>
+            <li>Добавлен генератор <code>_ingest_records()</code></li>
+            <li><code>source_page_map()</code> рефакторирована через <code>_ingest_records()</code></li>
+            <li><code>covered_sources()</code> рефакторирована: <code>_ingest_records()</code> + <code>_fresh()</code></li>
+            <li><code>hashlib</code> уже был импортирован — не добавлялся повторно ✓</li>
+            <li><code>test_iwiki_common.py</code>: <code>import hashlib</code>, 2 новых теста</li>
+          </ul>
+        </td>
+      </tr>
+      <tr>
+        <td>T3 · <code>iwiki-ingest/SKILL.md</code> + <code>iwiki-init/SKILL.md</code></td>
+        <td>
+          <ul style="margin:0; padding-left:1.2rem">
+            <li>Шаг 5 обоих SKILL.md: <code>printf</code>-блок добавляет <code>"src_hash":"%s"</code> через <code>$(sha256sum '&lt;src&gt;' | cut -c1-16)</code></li>
+            <li>Canonical record note обновлён: <code>{op, source, page, date, src_hash}</code></li>
+            <li>Пути <code>ENG="plugin/iwiki/engine"</code> и iclaude-ссылки не тронуты ✓</li>
+          </ul>
+        </td>
+      </tr>
+      <tr>
+        <td>T4 · Full-suite verification</td>
+        <td>
+          <ul style="margin:0; padding-left:1.2rem">
+            <li>61/61 тестов прошли (подтверждено пользователем)</li>
+            <li>class-2 пути не регрессированы (<code>plugin/iwiki/engine</code> сохранён во всех местах)</li>
+            <li><code>src_hash</code> присутствует в lint, hook и обоих SKILL.md</li>
+            <li><code>.claude_config</code> в <code>config.py</code> не тронут</li>
+          </ul>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+
+  <h3>Покрытие интента / спеки</h3>
+  <p><span class="badge muted">Интент: n/a</span> — цепочка открывается спекой.</p>
+
+  <table>
+    <thead><tr><th>#</th><th>Требование спеки</th><th>Статус</th></tr></thead>
+    <tbody>
+      <tr><td>1</td><td><code>_src_hash</code> и <code>_fresh</code> — точные зеркала в <code>lint.py</code> и <code>iwiki_common.py</code></td><td><span class="badge ok">✓ DONE</span></td></tr>
+      <tr><td>2</td><td><code>_stale</code> использует <code>_fresh</code> (отчёт = <code>not _fresh(...)</code>)</td><td><span class="badge ok">✓ DONE</span></td></tr>
+      <tr><td>3</td><td><code>covered_sources</code> использует <code>_fresh</code> — точная инверсия <code>_stale</code></td><td><span class="badge ok">✓ DONE</span></td></tr>
+      <tr><td>4</td><td><code>src_hash</code> в log-блоке SKILL.md для ingest и init</td><td><span class="badge ok">✓ DONE</span></td></tr>
+      <tr><td>5</td><td>Backward compatible: записи без <code>src_hash</code> → mtime-путь (неизменное поведение)</td><td><span class="badge ok">✓ DONE</span></td></tr>
+      <tr><td>6</td><td>iclaude-пути не регрессированы (<code>plugin/iwiki/engine</code> сохранён)</td><td><span class="badge ok">✓ DONE</span></td></tr>
+      <tr><td>7</td><td>6 новых тестов: 4 в <code>test_lint.py</code> + 2 в <code>test_iwiki_common.py</code></td><td><span class="badge ok">✓ DONE</span></td></tr>
+      <tr><td>8</td><td>НЕ тронуты: <code>config.py</code>, <code>test_chunk.py</code>, <code>plugin.json</code>, <code>marketplace.json</code></td><td><span class="badge ok">✓ DONE</span></td></tr>
+    </tbody>
+  </table>
+
+  <h3>Избыточные изменения (EXCESS)</h3>
+  <p class="note">Нет — все 6 файлов в diff точно соответствуют задачам плана.</p>
+
+  <h3>Findings</h3>
+  <table>
+    <thead><tr><th>Severity</th><th>Количество</th></tr></thead>
+    <tbody>
+      <tr><td><span class="badge crit">CRITICAL</span></td><td>0</td></tr>
+      <tr><td><span class="badge warn">WARNING</span></td><td>0</td></tr>
+      <tr><td><span class="badge muted">INFO</span></td><td>0</td></tr>
+    </tbody>
+  </table>
+
+  <div class="note" style="border-color:var(--ok); background:color-mix(in srgb,var(--ok) 10%,var(--surface)); color:var(--ok)">
+    <strong>Вердикт: OK</strong> — все 4 задачи плана выполнены, все 8 требований спеки покрыты, нет CRITICAL/WARNING/INFO findings. Цепочка готова к слиянию.
+  </div>
+
+  <h3>Цепочка</h3>
+  <p>
+    <span class="badge muted">intent: n/a</span> →
+    <span class="badge ok">spec: passed</span> →
+    <span class="badge ok">plan: passed</span> →
+    <span class="badge ok">result: OK</span>
+  </p>
+  <p class="note">
+    Цепочка: <code>intent (null)</code> → <code>docs/superpowers/specs/2026-06-30-iwiki-content-hash-freshness-port-design.md</code> → <code>docs/superpowers/plans/2026-06-30-iwiki-content-hash-freshness-port.md</code><br>
+    Plan hash: <code>af6f9cb06d18e442</code> · check-result: 2026-06-30
+  </p>
+
 </section>
 <!-- TAB:result END -->
 </main>

--- a/docs/superpowers/reports/iwiki-content-hash-freshness-port-results.html
+++ b/docs/superpowers/reports/iwiki-content-hash-freshness-port-results.html
@@ -82,8 +82,8 @@ svg{max-width:100%; height:auto; display:block; margin:1rem auto; background:var
 <body>
 <input type="checkbox" id="theme-toggle" hidden>
 <input type="radio" name="chain-tab" id="tab-intent" class="tab-radio" hidden>
-<input type="radio" name="chain-tab" id="tab-spec"   class="tab-radio" hidden checked>
-<input type="radio" name="chain-tab" id="tab-plan"   class="tab-radio" hidden>
+<input type="radio" name="chain-tab" id="tab-spec"   class="tab-radio" hidden>
+<input type="radio" name="chain-tab" id="tab-plan"   class="tab-radio" hidden checked>
 <input type="radio" name="chain-tab" id="tab-result" class="tab-radio" hidden>
 <header>
   <label for="theme-toggle" class="theme-btn" title="Переключить тему">🌙 / ☀️</label>
@@ -273,7 +273,141 @@ svg{max-width:100%; height:auto; display:block; margin:1rem auto; background:var
 <!-- TAB:spec END -->
 <!-- TAB:plan START -->
 <section class="tab-pane" id="pane-plan">
-  <p class="note">Этап ещё не проверён.</p>
+
+  <h2>1. Резюме плана</h2>
+  <p>
+    <strong>iwiki Content-Hash Freshness Port — Implementation Plan</strong><br>
+    План: <code>docs/superpowers/plans/2026-06-30-iwiki-content-hash-freshness-port.md</code> · <code>plan_hash: af6f9cb06d18e442</code><br>
+    Спека: <code>docs/superpowers/specs/2026-06-30-iwiki-content-hash-freshness-port-design.md</code> · <code>spec_hash: 46590f57fe2de22d</code>
+  </p>
+  <p class="note">
+    Цель: перенести content-addressed детекцию устаревания (поле <code>src_hash</code> в логе + предикат свежести «хеш с откатом на mtime») из standalone-репозитория <code>ai-wiki-plugin</code> в <code>iclaude/plugin/iwiki</code>, заменив проверку устаревания только-по-mtime. TDD-план, 4 задачи.
+  </p>
+
+  <h3>Шаги и их Definition of Done</h3>
+  <table>
+    <thead><tr><th>Задача</th><th>Шаг</th><th>Артефакт</th><th>Definition of Done</th></tr></thead>
+    <tbody>
+      <tr><td rowspan="7">T1 · Engine lint</td><td>1. Добавить падающие тесты</td><td><code>engine/tests/test_lint.py</code></td><td>Добавлен <code>import hashlib</code> и 4 новых теста.</td></tr>
+      <tr><td>2. Прогон — должны падать</td><td>—</td><td>FAIL: <code>test_stale_hash_match_overrides_older_page_mtime</code> падает; <code>test_stale_hash_present_but_unreadable_falls_back_to_mtime</code> ошибается на <code>monkeypatch _src_hash</code> (функции ещё нет).</td></tr>
+      <tr><td>3. <code>import hashlib</code> в lint.py</td><td><code>lint.py</code></td><td>Блок импорта содержит <code>hashlib</code> после <code>glob</code>.</td></tr>
+      <tr><td>4. Хелперы <code>_src_hash</code>, <code>_fresh</code></td><td><code>lint.py</code></td><td>Обе функции присутствуют на уровне модуля перед <code>_stale</code>.</td></tr>
+      <tr><td>5. Перевести <code>_stale</code> на <code>_fresh</code></td><td><code>lint.py</code></td><td>Сравнение заменено на <code>not _fresh(src, page, rec.get("src_hash"))</code>; docstring обновлён.</td></tr>
+      <tr><td>6. Прогон — должны проходить</td><td>—</td><td>PASS: все прежние + 4 новых теста.</td></tr>
+      <tr><td>7. Коммит</td><td>git</td><td>Коммит <code>feat(iwiki): content-hash staleness in engine lint</code> создан.</td></tr>
+
+      <tr><td rowspan="5">T2 · Stop-hook</td><td>1. Добавить падающие тесты</td><td><code>engine/tests/test_iwiki_common.py</code></td><td>Добавлен <code>import hashlib</code> и 2 новых теста.</td></tr>
+      <tr><td>2. Прогон — должны падать</td><td>—</td><td>FAIL обоих новых тестов на mtime-поведении.</td></tr>
+      <tr><td>3. Заменить <code>source_page_map</code> + <code>covered_sources</code></td><td><code>hooks/iwiki_common.py</code></td><td>Добавлены <code>_src_hash</code>/<code>_fresh</code>/<code>_ingest_records</code>; обе функции читают через них; путь <code>plugin/iwiki/engine</code> и docstring iclaude не тронуты.</td></tr>
+      <tr><td>4. Прогон — должны проходить</td><td>—</td><td>PASS: прежние + 2 новых теста.</td></tr>
+      <tr><td>5. Коммит</td><td>git</td><td>Коммит <code>feat(iwiki): content-hash coverage in Stop-hook</code> создан.</td></tr>
+
+      <tr><td rowspan="4">T3 · Skills</td><td>1. Обновить step-5 log-блок</td><td><code>skills/iwiki-ingest/SKILL.md</code></td><td>Блок печатает <code>src_hash</code> через <code>sha256sum '&lt;src&gt;' | cut -c1-16</code>; note обновлён; ENG fallback сохранён.</td></tr>
+      <tr><td>2. То же для init</td><td><code>skills/iwiki-init/SKILL.md</code></td><td>Блок и note обновлены; ENG fallback сохранён.</td></tr>
+      <tr><td>3. grep-проверка правок</td><td>—</td><td>Первый grep показывает <code>src_hash</code> в обоих файлах; второй — <code>ENG="plugin/iwiki/engine"</code> цел в обоих.</td></tr>
+      <tr><td>4. Коммит</td><td>git</td><td>Коммит <code>docs(iwiki): record src_hash in ingest/init log steps</code> создан.</td></tr>
+
+      <tr><td rowspan="2">T4 · Полная верификация</td><td>1. Полный прогон тестов движка</td><td>—</td><td>Все тесты зелёные, включая 6 новых.</td></tr>
+      <tr><td>2. Защита от регрессий класса-2 (3 grep)</td><td>—</td><td><code>plugin/iwiki/engine</code> не регрессировал в <code>engine</code>; <code>src_hash</code> присутствует в lint/hook/обоих skills; <code>.claude_config</code> цел в <code>config.py</code>.</td></tr>
+    </tbody>
+  </table>
+
+  <h2>2. Схемы зависимостей и пересечений</h2>
+
+  <h3>Граф зависимостей задач (M→N означает: результат задачи M используется в задаче N, M&lt;N)</h3>
+  <svg viewBox="0 0 720 300" role="img" aria-label="Граф зависимостей задач плана">
+    <defs>
+      <marker id="parr" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+        <path d="M0,0 L10,5 L0,10 z" fill="#4ea1ff"/>
+      </marker>
+      <filter id="pds" x="-20%" y="-20%" width="140%" height="140%">
+        <feDropShadow dx="0" dy="1" stdDeviation="1.5" flood-color="#000" flood-opacity="0.35"/>
+      </filter>
+    </defs>
+    <style>
+      .pn rect{fill:#222b38; stroke:#33404f; rx:8; filter:url(#pds);}
+      .pn.acc rect{stroke:#4ea1ff;}
+      .pn.ok rect{stroke:#3fb950;}
+      .pn text{fill:#e6edf3; font:600 12px sans-serif;}
+      .pn .sub{font:400 10px sans-serif; fill:#8b98a8;}
+      .pe{stroke:#4ea1ff; stroke-width:1.7; fill:none; marker-end:url(#parr);}
+      body:has(#theme-toggle:checked) .pn rect{fill:#eef2f6; stroke:#d0d7de;}
+      body:has(#theme-toggle:checked) .pn.acc rect{stroke:#0969da;}
+      body:has(#theme-toggle:checked) .pn.ok rect{stroke:#1a7f37;}
+      body:has(#theme-toggle:checked) .pn text{fill:#1f2328;}
+      body:has(#theme-toggle:checked) .pn .sub{fill:#5b6470;}
+      body:has(#theme-toggle:checked) .pe{stroke:#0969da;}
+    </style>
+    <!-- edges: T1->T2 (mirror), T1->T4, T2->T4, T3->T4 -->
+    <path class="pe" d="M190,80 L300,80"/>
+    <path class="pe" d="M190,90 L520,150"/>
+    <path class="pe" d="M420,90 L520,160"/>
+    <path class="pe" d="M190,215 L520,180"/>
+    <!-- nodes -->
+    <g class="pn acc"><rect x="40" y="55" width="150" height="56"/><text x="58" y="80">T1 Engine lint</text><text class="sub" x="58" y="98">_src_hash/_fresh/_stale</text></g>
+    <g class="pn"><rect x="300" y="55" width="120" height="56"/><text x="318" y="80">T2 Stop-hook</text><text class="sub" x="318" y="98">зеркало _fresh</text></g>
+    <g class="pn"><rect x="40" y="190" width="150" height="56"/><text x="58" y="215">T3 Skills</text><text class="sub" x="58" y="233">src_hash в логе</text></g>
+    <g class="pn ok"><rect x="520" y="135" width="160" height="56"/><text x="538" y="160">T4 Верификация</text><text class="sub" x="538" y="178">полный прогон + grep</text></g>
+  </svg>
+  <p class="note">
+    Циклов и нарушений порядка <strong>нет</strong>. T1→T2 — мягкая зависимость порядка (T2 <em>зеркалит</em> семантику <code>_fresh</code>, не импортирует). Внутри каждой задачи шаги строго последовательны TDD-циклом (red→green→commit). Единственное «использование до создания» — намеренная red-фаза TDD (тест ссылается на <code>_src_hash</code> до Шага 4 T1), явно задокументированная как ожидаемый FAIL в Шаге 2 — нарушением порядка не является.
+  </p>
+
+  <h3>Матрица пересечений (задачи/шаги, трогающие один артефакт)</h3>
+  <table>
+    <thead><tr><th>Артефакт</th><th>Пишет</th><th>Читает (grep/verify)</th></tr></thead>
+    <tbody>
+      <tr><td><code>engine/iwiki_engine/lint.py</code></td><td>T1 · S3,S4,S5</td><td>T4 · S2</td></tr>
+      <tr><td><code>engine/tests/test_lint.py</code></td><td>T1 · S1</td><td>—</td></tr>
+      <tr><td><code>engine/tests/test_iwiki_common.py</code></td><td>T2 · S1</td><td>—</td></tr>
+      <tr><td><code>hooks/iwiki_common.py</code></td><td>T2 · S3</td><td>T4 · S2</td></tr>
+      <tr><td><code>skills/iwiki-ingest/SKILL.md</code></td><td>T3 · S1</td><td>T3 · S3, T4 · S2</td></tr>
+      <tr><td><code>skills/iwiki-init/SKILL.md</code></td><td>T3 · S2</td><td>T3 · S3, T4 · S2</td></tr>
+      <tr><td><code>engine/iwiki_engine/config.py</code></td><td>— (не тронут)</td><td>T4 · S2 (<code>.claude_config</code> цел)</td></tr>
+    </tbody>
+  </table>
+  <p class="note">Покрытие требований: каждое требование спеки закрыто ≥1 шагом; ни одно требование не закрыто несколькими конфликтующими шагами; «лишних» шагов нет. 4 поведенческих проверки спеки → 6 тестов (4 lint + 2 hook).</p>
+
+  <h2>3. Результаты проверки</h2>
+
+  <h3>Фазы</h3>
+  <table>
+    <thead><tr><th>Фаза</th><th>Статус</th><th>Резюме</th></tr></thead>
+    <tbody>
+      <tr><td>structure</td><td><span class="badge ok">passed</span></td><td>Нет плейсхолдеров (TODO/TBD/???/FIXME); нумерация задач 1–4 и шагов без пропусков/дублей; дублей заголовков нет. <code>&lt;src&gt;</code>/<code>&lt;page&gt;</code> — намеренные runtime-токены skill-инструкций (помечены в «Notes for the executor»), не плановые плейсхолдеры.</td></tr>
+      <tr><td>coverage</td><td><span class="badge ok">passed</span></td><td>Каждое требование спеки (lint.py, test_lint.py, test_iwiki_common.py, hooks/iwiki_common.py, оба SKILL.md, раздел Verification) покрыто ≥1 шагом; каждый шаг привязан к требованию; лишних шагов нет.</td></tr>
+      <tr><td>dependencies</td><td><span class="badge ok">passed</span></td><td>Порядок шагов корректен; циклов нет; артефакты создаются до использования (единственное «использование до создания» — намеренная red-фаза TDD, задокументирована как ожидаемый FAIL).</td></tr>
+      <tr><td>verifiability</td><td><span class="badge ok">passed</span></td><td>У каждого шага измеримый DoD; нет размытых формулировок; тест/grep-шаги несут явные <code>Run:</code> и <code>Expected:</code>.</td></tr>
+      <tr><td>consistency</td><td><span class="badge ok">passed</span></td><td><code>spec_hash 46590f57fe2de22d</code> совпадает с телом спеки и с проходным review-блоком спеки; первичный прогон, дрейфа секций нет.</td></tr>
+    </tbody>
+  </table>
+
+  <h3>Findings</h3>
+  <table>
+    <thead><tr><th>id</th><th>severity</th><th>section</th><th>fragment</th><th>text</th><th>fix</th><th>verdict</th></tr></thead>
+    <tbody>
+      <tr><td colspan="7" style="text-align:center; color:var(--muted);">Находок нет — <code>findings: []</code></td></tr>
+    </tbody>
+  </table>
+
+  <h3>Сводка</h3>
+  <div class="summary-grid">
+    <div class="metric"><div class="v" style="color:var(--crit)">0</div><div class="l">CRITICAL open</div></div>
+    <div class="metric"><div class="v" style="color:var(--warn)">0</div><div class="l">WARNING open</div></div>
+    <div class="metric"><div class="v" style="color:var(--ok)">OK</div><div class="l">Вердикт</div></div>
+  </div>
+
+  <h3>Цепочка</h3>
+  <p>
+    <span class="badge muted">intent: n/a</span> →
+    <span class="badge ok">spec: passed</span> →
+    <span class="badge ok">plan: passed</span> →
+    <span class="badge muted">result: —</span>
+  </p>
+  <p class="note">
+    Цепочка: <code>intent (null)</code> → <code>docs/superpowers/specs/2026-06-30-iwiki-content-hash-freshness-port-design.md</code> → <code>docs/superpowers/plans/2026-06-30-iwiki-content-hash-freshness-port.md</code>.
+  </p>
+
 </section>
 <!-- TAB:plan END -->
 <!-- TAB:result START -->

--- a/docs/superpowers/specs/2026-06-30-iwiki-content-hash-freshness-port-design.md
+++ b/docs/superpowers/specs/2026-06-30-iwiki-content-hash-freshness-port-design.md
@@ -1,3 +1,30 @@
+---
+chain:
+  intent: null
+review:
+  spec_hash: 46590f57fe2de22d
+  last_run: 2026-06-30
+  phases:
+    structure:   { status: passed }
+    coverage:    { status: passed }
+    clarity:     { status: passed }
+    consistency: { status: passed }
+  section_hashes:
+    Problem: da7fa7e0a6482f57
+    "What ports (and only this)": e1eb8c824cfc7b1a
+    "Feature design": 1cbbf81723eeefda
+    "Log record": ad2840cfd8d88d71
+    "Freshness predicate (the invariant)": f1eeb1bd98d8fc33
+    "Backward / forward compatibility": a06261362c60f8b7
+    "Files changed": c990d93165d86ffa
+    "Explicitly NOT touched": 15781caf25f6856a
+    Verification: 30020994ef252c69
+    "Behavioural checks (covered by the new tests)": e084cb43817d7495
+    "Out of scope": e5ffaad14cd7eece
+    "Workflow note": 835cab1ea0494981
+  findings: []
+---
+
 # Port content-hash freshness from `ai-wiki-plugin` into `plugin/iwiki`
 
 **Date:** 2026-06-30

--- a/plugin/iwiki/engine/iwiki_engine/lint.py
+++ b/plugin/iwiki/engine/iwiki_engine/lint.py
@@ -8,6 +8,7 @@ an error — this is the fix for the exit-2 seen in foreign projects.
 from __future__ import annotations
 
 import glob
+import hashlib
 import json
 import os
 import re
@@ -48,9 +49,30 @@ def _resolve(slug: str, wiki_dir: str) -> str:
     return os.path.normpath(os.path.join(wiki_dir, t))
 
 
+def _src_hash(src: str) -> str | None:
+    """sha256 of the source's raw bytes, first 16 hex chars. None when the file
+    cannot be read — the caller then falls back to the mtime comparison."""
+    try:
+        with open(src, "rb") as fh:
+            return hashlib.sha256(fh.read()).hexdigest()[:16]
+    except OSError:
+        return None
+
+
+def _fresh(src: str, page: str, src_hash: str | None) -> bool:
+    """Is `page` current for `src`? Content-addressed when the log record
+    carries `src_hash` and the source is readable; otherwise the page is fresh
+    iff it is at least as new as the source by mtime (the prior behaviour)."""
+    if src_hash:
+        cur = _src_hash(src)
+        if cur is not None:
+            return cur == src_hash
+    return os.path.getmtime(page) >= os.path.getmtime(src)
+
+
 def _stale(wiki_dir: str) -> list[dict]:
     """Pages whose source changed after the last ingest, via .iwiki/log.jsonl
-    (mtime-based; no git). Deduped by page, first hit wins."""
+    (content-hash with mtime fallback; no git). Deduped by page, first hit wins."""
     log = os.path.join(wiki_dir, ".iwiki", "log.jsonl")
     if not os.path.isfile(log):
         return []
@@ -73,7 +95,7 @@ def _stale(wiki_dir: str) -> list[dict]:
             continue
         if os.path.isfile(src) and os.path.isfile(page):
             try:
-                if os.path.getmtime(src) > os.path.getmtime(page):
+                if not _fresh(src, page, rec.get("src_hash")):
                     out.append({"page": page, "source": src})
                     seen.add(page)
             except Exception:

--- a/plugin/iwiki/engine/tests/test_iwiki_common.py
+++ b/plugin/iwiki/engine/tests/test_iwiki_common.py
@@ -1,4 +1,5 @@
 import contextlib
+import hashlib
 import io
 import json as _json
 import os
@@ -126,3 +127,30 @@ def test_iwikiignore_comment_only_is_noop(tmp_path, monkeypatch):
     (tmp_path / ".iwikiignore").write_text("# just a comment\n\n", encoding="utf-8")
     assert iwiki_common.source_ignore() is None
     assert iwiki_common.is_documentable("lib/foo/bar.py") is True
+
+
+def test_covered_sources_hash_match_overrides_mtime(tmp_path, monkeypatch):
+    # Cure case mirror of the engine test: page OLDER by mtime but hash matches
+    # → still covered.
+    log = _setup_wiki(tmp_path, monkeypatch)
+    (tmp_path / "a.py").write_text("x", encoding="utf-8")
+    (tmp_path / "docs" / "wiki" / "a.md").write_text("y", encoding="utf-8")
+    h = hashlib.sha256(b"x").hexdigest()[:16]
+    _write_log(log, [
+        {"op": "ingest", "source": "a.py", "page": "docs/wiki/a.md", "src_hash": h}])
+    os.utime("a.py", (3000, 3000))
+    os.utime("docs/wiki/a.md", (1000, 1000))
+    assert iwiki_common.covered_sources() == {"a.py"}
+
+
+def test_covered_sources_hash_mismatch_not_covered(tmp_path, monkeypatch):
+    # Page NEWER by mtime but hash differs → not covered.
+    log = _setup_wiki(tmp_path, monkeypatch)
+    (tmp_path / "a.py").write_text("x", encoding="utf-8")
+    (tmp_path / "docs" / "wiki" / "a.md").write_text("y", encoding="utf-8")
+    _write_log(log, [
+        {"op": "ingest", "source": "a.py", "page": "docs/wiki/a.md",
+         "src_hash": "0000000000000000"}])
+    os.utime("a.py", (1000, 1000))
+    os.utime("docs/wiki/a.md", (2000, 2000))
+    assert iwiki_common.covered_sources() == set()

--- a/plugin/iwiki/engine/tests/test_lint.py
+++ b/plugin/iwiki/engine/tests/test_lint.py
@@ -1,5 +1,6 @@
 import json
 import os
+import hashlib
 from iwiki_engine.lint import lint
 
 
@@ -59,3 +60,65 @@ def test_section_findings_folded_into_report(tmp_path):
     assert "deep_heading" in types
     assert "missing_overview" in types
     assert all("page" in f for f in out["sections"])
+
+
+def _h(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()[:16]
+
+
+def _wiki_with_log(tmp_path, page_body, src_body, src_hash=None):
+    """Wiki dir with one page, one source file, and a single ingest log record
+    (absolute paths). Returns (wiki_dir, src_path, page_path)."""
+    wd = tmp_path / "wiki"
+    wd.mkdir()
+    page = wd / "a.md"
+    page.write_text(page_body, encoding="utf-8")
+    src = tmp_path / "a.py"
+    src.write_text(src_body, encoding="utf-8")
+    iwiki = wd / ".iwiki"
+    iwiki.mkdir()
+    rec = {"op": "ingest", "source": str(src), "page": str(page)}
+    if src_hash is not None:
+        rec["src_hash"] = src_hash
+    (iwiki / "log.jsonl").write_text(json.dumps(rec) + "\n", encoding="utf-8")
+    return str(wd), str(src), str(page)
+
+
+def test_stale_hash_match_overrides_older_page_mtime(tmp_path):
+    # The cure case: page mtime OLDER than source, but src_hash matches the
+    # current source → NOT stale (kills git-reset / same-day false positives).
+    wd, src, page = _wiki_with_log(
+        tmp_path, "## A\nbody\n", "print('x')\n", src_hash=_h("print('x')\n"))
+    os.utime(src, (2000, 2000))
+    os.utime(page, (1000, 1000))
+    assert lint(wd)["stale"] == []
+
+
+def test_stale_hash_mismatch_is_stale_even_if_page_newer(tmp_path):
+    # Hash recorded for OLD content; source now differs → stale regardless of mtime.
+    wd, src, page = _wiki_with_log(
+        tmp_path, "## A\nbody\n", "new content\n", src_hash=_h("old content\n"))
+    os.utime(src, (1000, 1000))
+    os.utime(page, (2000, 2000))
+    assert any(s["source"] == src for s in lint(wd)["stale"])
+
+
+def test_stale_without_hash_uses_mtime(tmp_path):
+    # No src_hash in the record → unchanged mtime behaviour.
+    wd, src, page = _wiki_with_log(tmp_path, "## A\nbody\n", "x\n")
+    os.utime(src, (2000, 2000))
+    os.utime(page, (1000, 1000))
+    assert any(s["source"] == src for s in lint(wd)["stale"])
+    os.utime(page, (3000, 3000))
+    assert lint(wd)["stale"] == []
+
+
+def test_stale_hash_present_but_unreadable_falls_back_to_mtime(tmp_path, monkeypatch):
+    # src_hash present but source unreadable (_src_hash → None) → mtime path.
+    import iwiki_engine.lint as lintmod
+    wd, src, page = _wiki_with_log(
+        tmp_path, "## A\nbody\n", "x\n", src_hash="deadbeefdeadbeef")
+    monkeypatch.setattr(lintmod, "_src_hash", lambda p: None)
+    os.utime(src, (2000, 2000))
+    os.utime(page, (1000, 1000))
+    assert any(s["source"] == src for s in lint(wd)["stale"])

--- a/plugin/iwiki/hooks/iwiki_common.py
+++ b/plugin/iwiki/hooks/iwiki_common.py
@@ -274,17 +274,35 @@ def committed_sources(since: str) -> list[str]:
     return sorted(p for p in raw if is_documentable(p) and os.path.exists(p))
 
 
-def source_page_map() -> dict[str, str]:
-    """Map each source → its most recent wiki page from the ingest log
-    (docs/wiki/.iwiki/log.jsonl). Last record wins per source. Same record
-    predicate as the engine's lint._stale: any record carrying both `source`
-    and `page` counts (no `op` filter). Fail-soft → {}."""
-    out: dict[str, str] = {}
+def _src_hash(src: str) -> str | None:
+    """sha256 of the source's raw bytes, first 16 hex chars; None if unreadable.
+    Mirror of engine lint._src_hash."""
+    try:
+        with open(src, "rb") as fh:
+            return hashlib.sha256(fh.read()).hexdigest()[:16]
+    except OSError:
+        return None
+
+
+def _fresh(src: str, page: str, src_hash: str | None) -> bool:
+    """Is `page` current for `src`? Content-addressed when the record carries
+    `src_hash` and the source is readable; else mtime (page >= source). The
+    exact mirror of engine lint._fresh."""
+    if src_hash:
+        cur = _src_hash(src)
+        if cur is not None:
+            return cur == src_hash
+    return os.path.getmtime(page) >= os.path.getmtime(src)
+
+
+def _ingest_records():
+    """Yield each well-formed log record (a dict carrying both `source` and
+    `page`) from docs/wiki/.iwiki/log.jsonl, oldest first. Fail-soft → nothing."""
     try:
         with open(LOG_REL, encoding="utf-8") as f:
             lines = f.read().splitlines()
     except Exception:
-        return out
+        return
     for line in lines:
         line = line.strip()
         if not line:
@@ -295,24 +313,35 @@ def source_page_map() -> dict[str, str]:
                 continue
         except Exception:
             continue
-        src, page = rec.get("source"), rec.get("page")
-        if src and page:
-            out[src] = page          # last record wins
+        if rec.get("source") and rec.get("page"):
+            yield rec
+
+
+def source_page_map() -> dict[str, str]:
+    """Map each source → its most recent wiki page from the ingest log
+    (docs/wiki/.iwiki/log.jsonl). Last record wins per source. A record counts
+    when it carries both `source` and `page`. Fail-soft → {}."""
+    out: dict[str, str] = {}
+    for rec in _ingest_records():
+        out[rec["source"]] = rec["page"]          # last record wins
     return out
 
 
 def covered_sources() -> set[str]:
     """Sources already covered by a fresh wiki page: the source's most recent
-    page (per source_page_map) exists on disk and is at least as new as the
-    source. The freshness test mtime(page) >= mtime(source) is the exact
-    inverse of lint._stale, so for any (source, page) pair this calls "covered"
-    exactly the pairs lint would not call stale. Fail-soft → empty set (subtract
-    nothing → safe over-nag, bounded by MAX_ASK)."""
+    log record names a page that exists on disk and is fresh for the source
+    (hash match when the record has `src_hash`, else page mtime >= source).
+    The freshness test is the exact inverse of lint._stale. Fail-soft → empty
+    set (subtract nothing → safe over-nag, bounded by MAX_ASK)."""
+    latest: dict[str, dict] = {}
+    for rec in _ingest_records():
+        latest[rec["source"]] = rec               # last record wins
     covered: set[str] = set()
-    for src, page in source_page_map().items():
+    for src, rec in latest.items():
+        page = rec["page"]
         try:
             if os.path.isfile(src) and os.path.isfile(page) \
-                    and os.path.getmtime(page) >= os.path.getmtime(src):
+                    and _fresh(src, page, rec.get("src_hash")):
                 covered.add(src)
         except Exception:
             continue

--- a/plugin/iwiki/skills/iwiki-ingest/SKILL.md
+++ b/plugin/iwiki/skills/iwiki-ingest/SKILL.md
@@ -65,12 +65,16 @@ You do NOT need iclaude's `lib/` — only the plugin and `IWIKI_LLM_*` config.
    Expected: `indexed: N chunks (... reused, ... embedded), <bytes>`.
 5. Append an operation record to `docs/wiki/.iwiki/log.jsonl`:
    ```bash
-   printf '{"op":"ingest","source":"<src>","page":"<page>","date":"<YYYY-MM-DD>"}\n' \
+   printf '{"op":"ingest","source":"<src>","page":"<page>","date":"<YYYY-MM-DD>","src_hash":"%s"}\n' \
+     "$(sha256sum '<src>' | cut -c1-16)" \
      >> docs/wiki/.iwiki/log.jsonl
    ```
-   Canonical log record: `{op, source, page, date}` (`note` optional). Use exactly
-   these keys — `lint`'s stale check reads `source`/`page` and ignores records
-   missing them. Do not introduce alternative keys (e.g. `scope`).
+   Substitute `<src>` (same path in both the `source` field and the `sha256sum`
+   argument), `<page>`, and `<YYYY-MM-DD>` literally; `src_hash` is filled by the
+   shell. Canonical log record: `{op, source, page, date, src_hash}` (`note`
+   optional). `src_hash` is the sha256 of the source's raw bytes, first 16 hex
+   chars — `lint`'s stale check prefers it over mtime. Use exactly these keys;
+   do not introduce alternatives (e.g. `scope`).
 6. Report which page changed and the index size (warn if over the 8 MB cap).
 
 ## Stop rule

--- a/plugin/iwiki/skills/iwiki-init/SKILL.md
+++ b/plugin/iwiki/skills/iwiki-init/SKILL.md
@@ -61,12 +61,16 @@ indexes everything. Works in any project — the engine ships with this plugin
 5. **Log the bootstrap.** Append one record per generated page to
    `docs/wiki/.iwiki/log.jsonl`:
    ```bash
-   printf '{"op":"init","source":"<src>","page":"<page>","date":"<YYYY-MM-DD>"}\n' \
+   printf '{"op":"init","source":"<src>","page":"<page>","date":"<YYYY-MM-DD>","src_hash":"%s"}\n' \
+     "$(sha256sum '<src>' | cut -c1-16)" \
      >> docs/wiki/.iwiki/log.jsonl
    ```
-   Canonical log record: `{op, source, page, date}` (`note` optional). Use exactly
-   these keys — `lint`'s stale check reads `source`/`page` and ignores records
-   missing them. Do not introduce alternative keys (e.g. `scope`).
+   Substitute `<src>` (same path in both the `source` field and the `sha256sum`
+   argument), `<page>`, and `<YYYY-MM-DD>` literally; `src_hash` is filled by the
+   shell. Canonical log record: `{op, source, page, date, src_hash}` (`note`
+   optional). `src_hash` is the sha256 of the source's raw bytes, first 16 hex
+   chars — `lint`'s stale check prefers it over mtime. Use exactly these keys;
+   do not introduce alternatives (e.g. `scope`).
 
 6. **Lint + summarize.** Invoke the `iwiki:iwiki-lint` skill (or run the checks)
    and report: pages created, chunk count, index size, and any gaps (source areas


### PR DESCRIPTION
## Problem

Wiki-page staleness in `plugin/iwiki` was decided purely by mtime
(`mtime(page) >= mtime(source)`). mtime is an unreliable proxy: `git reset`/
`checkout`, same-day edits, and file copies move the timestamp without changing
content, producing spurious `lint` "stale" reports and spurious Stop-hook nags.

The standalone `ai-wiki-plugin` repo had already fixed this with content-addressed
staleness detection; that improvement was missing from the bundled `plugin/iwiki`.
This PR ports **only** that feature.

## What changed

- **Log record** — `iwiki-ingest` / `iwiki-init` skills now append `src_hash`
  (`sha256(source raw bytes)[:16]`, via `sha256sum '<src>' | cut -c1-16`) to
  `docs/wiki/.iwiki/log.jsonl`. The key is optional.
- **Engine lint** (`lint.py`) — new `_src_hash` / `_fresh`; `_stale` now reports a
  page iff `not _fresh(...)`: compare by content hash when the record carries
  `src_hash` and the source is readable, else fall back to the prior mtime rule.
- **Stop-hook** (`iwiki_common.py`) — `_src_hash` / `_fresh` / `_ingest_records`
  mirror the engine; `covered_sources` / `source_page_map` refactored onto them.
  `_fresh` is an exact mirror of the engine's, and `covered_sources` stays the
  exact inverse of `lint._stale`.

## Deliberately NOT ported (standalone de-specialization)

The standalone also genericized paths/text away from iclaude; those are wrong here
and were left intact: the `plugin/iwiki/engine` engine-path candidates (hook + all
skills), the `.claude_config` wording in `config.py`, the `lib/iwiki` / "iclaude"
docstring references, the version bump, and `marketplace.json`.

## Compatibility

Backward compatible: log records without `src_hash` keep the exact prior mtime
behaviour. No migration, no backfill.

## Tests

Full engine suite green (61/61), including 6 new tests (4 in `test_lint.py`,
2 in `test_iwiki_common.py`) covering hash-match-overrides-mtime, hash-mismatch,
no-hash mtime fallback, and unreadable-source fallback.

Built via the IDD→SDD chain (spec / plan / result all gated OK; final whole-branch
review: ready to merge, 0 critical / 0 important).

🤖 Generated with [Claude Code](https://claude.com/claude-code)