### PR TITLE
docs(loen): __pycache__ warning in loop-repair (0.2.1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -15,7 +15,7 @@
     {
       "name": "loen",
       "description": "Loop Engineering harness plugin: controlled agent loop, independent verifier, artifact-layout guardrails.",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "source": "./plugin/loen",
       "author": { "name": "ikeniborn" },
       "category": "development"

--- a/plugin/loen/.claude-plugin/plugin.json
+++ b/plugin/loen/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "loen",
   "description": "Loop Engineering harness: run a controlled Plan→Act→Check→Report agent loop with an independent verifier, a machine-readable loop.yaml contract, and hard artifact-layout guardrails.",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "author": { "name": "ikeniborn" },
   "keywords": ["loop-engineering", "agent-loop", "verifier", "workflow", "guardrails", "tdd"],
   "license": "MIT",

--- a/plugin/loen/skills/loop-repair/SKILL.md
+++ b/plugin/loen/skills/loop-repair/SKILL.md
@@ -28,7 +28,9 @@ layout, contract, audit gates, subagents, and hook. Shared templates live at
    + exit code into `docs/loen/<run-id>/iterations/iter-01/gates.log`. For a suspected
    flaky failure run the command up to 3 times (attempts recorded in `state.md`); any
    failing run counts as reproduced. **No reproduction → stop and report** — never "fix"
-   what cannot be reproduced.
+   what cannot be reproduced. Python targets: purge `__pycache__` (or point
+   `PYTHONPYCACHEPREFIX` at a temp dir) before repro, inversion, and gate runs — a stale
+   `.pyc` of identical size and mtime second can mask the fix or the failure.
 4. **Isolate + minimal fix.** The smallest diff that makes the failing command pass. Save
    `iterations/iter-NN/diff.patch` (`git diff > …`, `iter-NN` zero-padded). Every non-test
    hunk must be required for the failing command to pass; tests change only by ADDING the


### PR DESCRIPTION
## Summary

One-line hardening note in `loop-repair/SKILL.md` step 3, found during the live 0.2.0 smoke run: a fixed Python module of identical byte size edited within the same mtime second defeats `.pyc` invalidation, so a stale `__pycache__` can mask the fix (or the failure) during repro/inversion/gate runs. The skill now instructs purging `__pycache__` (or pointing `PYTHONPYCACHEPREFIX` at a temp dir) on Python targets. Plugin bumped 0.2.0 → 0.2.1 (both manifests, sync check green).

## Test plan

- [x] `bash scripts/check-plugin-version-sync.sh` — OK
- [x] `bash tests/test_loen_plugin.sh` — PASS (skill lint + version sync 0.2.1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)