### PR TITLE
feat(nvm): enforce engines.node with node-TLS fallback installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,6 +365,27 @@ experiments.jsonl, report.html, pr-summary.md). В research-режиме eval п
 ./iclaude.sh --check-statusline # Статус статуслайна
 ```
 
+**Версия Node.js.** `--update` держит Node.js изолированной среды не ниже
+`engines.node` Claude Code. Перед `npm install` он читает требование пакета и,
+если активный мажор устарел (например, v20 при требуемом v22), **предлагает**
+(prompt, по умолчанию «да») поставить нужный мажор внутри изолированной среды.
+Глобальные пакеты лежат в общем префиксе `npm-global`, поэтому переживают смену
+Node без миграции. Если отказаться или все способы скачивания провалились,
+обновление **прерывается** — иначе установился бы Claude Code, который выдаёт
+`EBADENGINE` или не запустится. Проверка срабатывает даже когда Claude Code уже
+последней версии. Новые установки используют Node 22 по умолчанию.
+
+Скачивание Node идёт двумя путями. Сначала `nvm install <major>` (системный
+`curl`). Если он падает — системный OpenSSL не может завершить TLS-хендшейк к
+`nodejs.org` (`x509 unsupported algorithm`: GOST-патченный OpenSSL в AltLinux
+или TLS-перехватывающий прокси; падает даже с `-k` и даже мимо прокси) —
+включается fallback `fetch_node_via_node_tls`: `scripts/fetch-node.js` качает
+tarball **через собственный TLS-стек Node** (по той же причине, по которой `npm`
+работает, а `curl` нет), сверяет `SHASUMS256.txt` (sha256) и распаковывает в
+`versions/node/`. Тот же fallback использует `install_isolated_nodejs`, поэтому
+`--update` и `--isolated-install` чинятся сами; fetcher может стартовать на
+системном Node, если в изоляторе Node ещё нет.
+
 ---
 
 ## Workflow разработки: IDD → iwiki → brainstorm

--- a/lib/lockfile/install.sh
+++ b/lib/lockfile/install.sh
@@ -26,7 +26,7 @@ install_from_lockfile() {
 	echo ""
 
 	# Parse lockfile (using grep for portability)
-	local node_version=$(grep -oP '"nodeVersion":\s*"\K[^"]+' "$ISOLATED_LOCKFILE" 2>/dev/null || echo "18")
+	local node_version=$(grep -oP '"nodeVersion":\s*"\K[^"]+' "$ISOLATED_LOCKFILE" 2>/dev/null || echo "22")
 	local claude_version=$(grep -oP '"claudeCodeVersion":\s*"\K[^"]+' "$ISOLATED_LOCKFILE" 2>/dev/null || echo "")
 
 	print_info "Node.js version from lockfile: $node_version"

--- a/lib/nvm/install.sh
+++ b/lib/nvm/install.sh
@@ -86,13 +86,13 @@ install_isolated_nvm() {
 #######################################
 # Install Node.js in isolated NVM
 # Arguments:
-#   $1 - Node.js version (default: 18)
+#   $1 - Node.js version (default: 22)
 # Returns:
 #   0 - success
 #   1 - error
 #######################################
 install_isolated_nodejs() {
-	local node_version=${1:-20}
+	local node_version=${1:-22}
 
 	setup_isolated_nvm
 
@@ -115,13 +115,20 @@ install_isolated_nodejs() {
 	print_info "Installing Node.js $node_version to isolated environment..."
 	echo ""
 
-	# Install and use Node.js
-	nvm install "$node_version"
-	nvm use "$node_version"
-
-	if [[ $? -ne 0 ]]; then
-		print_error "Failed to install Node.js"
-		return 1
+	# Install and use Node.js. If nvm's download fails (system curl/OpenSSL cannot
+	# reach the Node mirror on this host), fall back to Node's own TLS stack.
+	if ! nvm install "$node_version" || ! nvm use "$node_version"; then
+		print_warning "nvm could not download Node.js; trying the node-TLS fallback..."
+		echo ""
+		local major="${node_version%%.*}"
+		if fetch_node_via_node_tls "$major"; then
+			local newdir
+			newdir="$(find "$NVM_DIR/versions/node" -maxdepth 1 -type d -name "v${major}.*" 2>/dev/null | LC_ALL=C sort | tail -1)"
+			[[ -n "$newdir" ]] && { nvm use "$(basename "$newdir")" &>/dev/null || export PATH="$newdir/bin:$PATH"; }
+		else
+			print_error "Failed to install Node.js"
+			return 1
+		fi
 	fi
 
 	print_success "Node.js $node_version installed"
@@ -130,6 +137,211 @@ install_isolated_nodejs() {
 	echo ""
 
 	return 0
+}
+
+#######################################
+# Fallback Node.js installer using Node's own TLS stack.
+# Downloads the latest release for a given major from nodejs.org into the
+# isolated nvm versions dir, bypassing system curl/nvm — whose OpenSSL cannot
+# complete a TLS handshake to nodejs.org on some hosts (e.g. AltLinux's
+# GOST-patched OpenSSL, or a TLS-intercepting proxy), while Node's own OpenSSL
+# can. Integrity is verified against SHASUMS256.txt (the TLS certs go unverified,
+# so this checksum is what guards the download). The heavy lifting is in
+# scripts/fetch-node.js.
+# Arguments:
+#   $1 - Node.js major version (e.g. "22")
+# Returns:
+#   0 - a Node.js <major>.x was downloaded, verified and extracted
+#   1 - failure
+#######################################
+fetch_node_via_node_tls() {
+	local major="$1"
+	local fetch_js="$SCRIPT_DIR/scripts/fetch-node.js"
+
+	if [[ ! -f "$fetch_js" ]]; then
+		print_error "Fetcher not found: $fetch_js"
+		return 1
+	fi
+
+	# Any working node can run the fetcher: prefer the highest isolated one, fall
+	# back to a system node (needed on a first, node-less install).
+	local runner
+	runner="$(find "$NVM_DIR/versions/node" -maxdepth 1 -type d -name "v*" 2>/dev/null | LC_ALL=C sort | tail -1)/bin/node"
+	[[ -x "$runner" ]] || runner="$(command -v node 2>/dev/null)"
+	if [[ -z "$runner" ]] || [[ ! -x "$runner" ]]; then
+		print_error "No Node.js available to run the TLS fetcher"
+		return 1
+	fi
+
+	# Make the proxy visible to the fetcher (isolated config holds ICLAUDE_PROXY_URL).
+	if [[ -z "${ICLAUDE_PROXY_URL:-}" ]] && declare -f source_iclaude_config &>/dev/null; then
+		source_iclaude_config 2>/dev/null || true
+	fi
+
+	# Arch tag used by nodejs.org tarball names.
+	local arch
+	case "$(uname -m)" in
+		x86_64) arch="x64" ;;
+		aarch64 | arm64) arch="arm64" ;;
+		armv7l) arch="armv7l" ;;
+		ppc64le) arch="ppc64le" ;;
+		s390x) arch="s390x" ;;
+		*) print_error "Unsupported architecture: $(uname -m)"; return 1 ;;
+	esac
+
+	local tmpd
+	tmpd="$(mktemp -d)"
+
+	print_info "Resolving latest Node.js $major (node-TLS; system curl cannot reach the mirror)..."
+	if ! "$runner" "$fetch_js" "https://nodejs.org/dist/index.json" "$tmpd/index.json"; then
+		print_error "Failed to fetch the Node.js release index"
+		rm -rf "$tmpd"
+		return 1
+	fi
+
+	# index.json is newest-first; take the first entry for this major.
+	local ver
+	ver="$("$runner" -e '
+		const fs = require("fs");
+		const list = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+		const hit = list.find(r => r.version.startsWith("v" + process.argv[2] + "."));
+		process.stdout.write(hit ? hit.version : "");
+	' "$tmpd/index.json" "$major")"
+
+	if [[ -z "$ver" ]]; then
+		print_error "No Node.js $major release found in the index"
+		rm -rf "$tmpd"
+		return 1
+	fi
+
+	local tarball="node-${ver}-linux-${arch}.tar.xz"
+	print_info "Downloading $tarball ..."
+	if ! "$runner" "$fetch_js" "https://nodejs.org/dist/${ver}/${tarball}" "$tmpd/$tarball"; then
+		print_error "Failed to download $tarball"
+		rm -rf "$tmpd"
+		return 1
+	fi
+	if ! "$runner" "$fetch_js" "https://nodejs.org/dist/${ver}/SHASUMS256.txt" "$tmpd/SHASUMS256.txt"; then
+		print_error "Failed to download SHASUMS256.txt"
+		rm -rf "$tmpd"
+		return 1
+	fi
+
+	# Verify integrity — the TLS certs are unverified, so this checksum matters.
+	local expected actual
+	expected="$(grep "  ${tarball}\$" "$tmpd/SHASUMS256.txt" | awk '{print $1}')"
+	actual="$(sha256sum "$tmpd/$tarball" | awk '{print $1}')"
+	if [[ -z "$expected" ]] || [[ "$expected" != "$actual" ]]; then
+		print_error "SHA256 mismatch for $tarball (expected: ${expected:-none}, got: $actual)"
+		rm -rf "$tmpd"
+		return 1
+	fi
+	print_success "SHA256 verified"
+
+	# Extract into the nvm versions layout so nvm and the launcher pick it up.
+	local dest="$NVM_DIR/versions/node/${ver}"
+	mkdir -p "$dest"
+	if ! tar -xJf "$tmpd/$tarball" -C "$dest" --strip-components=1; then
+		print_error "Failed to extract $tarball"
+		rm -rf "$tmpd" "$dest"
+		return 1
+	fi
+	rm -rf "$tmpd"
+
+	if [[ ! -x "$dest/bin/node" ]]; then
+		print_error "Node binary missing after extraction"
+		return 1
+	fi
+
+	print_success "Node.js $("$dest/bin/node" --version) installed to isolated env (node-TLS)"
+	return 0
+}
+
+#######################################
+# Ensure the active isolated Node.js satisfies a package's engines.node.
+# When the active Node is too old, offer to install the required major into the
+# isolated nvm and switch to it, so npm never emits EBADENGINE for the package.
+# Global packages live in the shared npm-global prefix (NPM_CONFIG_PREFIX) and
+# survive the Node switch, so no per-version package migration is performed.
+# Requires nvm.sh to be already sourced by the caller.
+# Arguments:
+#   $1 - package spec to query (default: @anthropic-ai/claude-code@latest)
+# Returns:
+#   0 - Node satisfies the requirement (was fine, or upgraded successfully)
+#   1 - Node is still too old (user declined, or the install failed)
+#######################################
+ensure_isolated_node_engine() {
+	local pkg="${1:-@anthropic-ai/claude-code@latest}"
+
+	# nvm must be available to install/switch versions; otherwise skip silently.
+	command -v nvm &>/dev/null || return 0
+
+	# Minimum required major from engines.node (e.g. ">=22.0.0" -> 22).
+	local engine_range required_major
+	engine_range=$(npm view "$pkg" engines.node 2>/dev/null)
+	required_major=$(echo "$engine_range" | grep -oE '[0-9]+' | head -1)
+	[[ -z "$required_major" ]] && return 0  # unknown requirement -> nothing to enforce
+
+	# Current active Node major.
+	local current_major
+	current_major=$(node --version 2>/dev/null | grep -oE '[0-9]+' | head -1)
+	[[ -z "$current_major" ]] && return 0
+
+	# Already new enough.
+	(( current_major >= required_major )) && return 0
+
+	print_warning "Node.js v$current_major is too old for $pkg (requires >= v$required_major)"
+	echo ""
+
+	# Offer before touching the environment; default yes (empty answer accepts).
+	local answer
+	read -r -p "Install Node.js $required_major into the isolated environment now? (Y/n): " answer
+	if [[ "$answer" =~ ^[Nn]$ ]]; then
+		print_info "Skipped Node.js upgrade — Claude Code $required_major+ may warn or fail on Node.js v$current_major"
+		echo ""
+		return 1
+	fi
+
+	print_info "Installing Node.js $required_major via the isolated nvm..."
+	echo ""
+
+	# Globals stay in npm-global (NPM_CONFIG_PREFIX), so a plain install + use is
+	# enough; the launcher (setup_isolated_nvm) then picks the highest version.
+	if nvm install "$required_major" && nvm use "$required_major"; then
+		print_success "Node.js upgraded to $(node --version) (isolated)"
+		echo ""
+		return 0
+	fi
+
+	# nvm's download failed — commonly the system curl/OpenSSL cannot reach the
+	# Node mirror on this host (e.g. 'TLS unsupported algorithm'), while Node's own
+	# TLS can. Fall back to the node-TLS fetcher before giving up.
+	echo ""
+	print_warning "nvm could not download Node.js; trying the node-TLS fallback..."
+	echo ""
+	if fetch_node_via_node_tls "$required_major"; then
+		# Activate the freshly extracted version for the rest of this process.
+		local newdir
+		newdir="$(find "$NVM_DIR/versions/node" -maxdepth 1 -type d -name "v${required_major}.*" 2>/dev/null | LC_ALL=C sort | tail -1)"
+		if [[ -n "$newdir" ]]; then
+			nvm use "$(basename "$newdir")" &>/dev/null || export PATH="$newdir/bin:$PATH"
+		fi
+		print_success "Node.js upgraded to $(node --version) (isolated, node-TLS)"
+		echo ""
+		return 0
+	fi
+
+	# Both paths failed — actionable guidance.
+	echo ""
+	print_error "Failed to install Node.js $required_major in the isolated environment"
+	echo ""
+	echo "Neither nvm (system curl) nor the node-TLS fallback could fetch Node.js."
+	echo "Check network/proxy reachability to nodejs.org, or:"
+	echo "  • point nvm at a reachable mirror: export NVM_NODEJS_ORG_MIRROR=<mirror>"
+	echo "  • or drop a Node.js $required_major build under:"
+	echo "      $NVM_DIR/versions/node/v$required_major.<minor>.<patch>/"
+	echo "  then re-run: iclaude --update"
+	return 1
 }
 
 #######################################

--- a/lib/update/update.sh
+++ b/lib/update/update.sh
@@ -42,6 +42,22 @@ update_claude_code() {
         fi
     fi
 
+    # Ensure Node.js satisfies Claude Code's engines.node BEFORE any npm work.
+    # Runs even when Claude Code is already up to date (that path returns early
+    # below), so a stale Node (e.g. v20 vs the required v22) is caught. If Node is
+    # too old and cannot be upgraded (declined or download failed), abort rather
+    # than install a Claude Code that would warn (EBADENGINE) or fail to run.
+    if [[ "$is_isolated" == true ]]; then
+        if ! ensure_isolated_node_engine "@anthropic-ai/claude-code@latest"; then
+            print_error "Update aborted — Node.js does not meet Claude Code's requirement"
+            echo ""
+            echo "Upgrade Node.js in the isolated environment (see above), then run:"
+            echo "  iclaude --update"
+            return 1
+        fi
+        echo ""
+    fi
+
     # Check if running with sudo (only required for system installations)
     if [[ "$using_nvm" == false ]] && [[ $EUID -ne 0 ]]; then
         print_error "Update requires sudo privileges for system installation"

--- a/scripts/fetch-node.js
+++ b/scripts/fetch-node.js
@@ -1,0 +1,143 @@
+#!/usr/bin/env node
+/*
+ * fetch-node.js — fetch an HTTPS URL using Node's own TLS stack.
+ *
+ * Why this exists: on some hosts (e.g. AltLinux with a GOST-patched OpenSSL, or
+ * behind a TLS-intercepting proxy) the system `curl`/OpenSSL cannot complete a
+ * TLS handshake to nodejs.org — it fails at `x509_pubkey_decode:unsupported
+ * algorithm`, even with `-k` and even when bypassing the proxy. `nvm` shells out
+ * to that curl, so `nvm install <version>` fails. Node's bundled OpenSSL accepts
+ * the same certificates (this is why `npm install` keeps working), so we do the
+ * download with Node instead. This is the fallback path for the isolated Node
+ * installer — see `fetch_node_via_node_tls` in lib/nvm/install.sh.
+ *
+ * Usage:  node fetch-node.js <httpsUrl> [outFile]
+ *   - writes the body to <outFile>, or to stdout if omitted
+ *   - exit 0 on HTTP 200, non-zero otherwise
+ *
+ * Proxy: read from ICLAUDE_PROXY_URL, then HTTPS_PROXY/https_proxy. Supports an
+ * HTTPS proxy (TLS to the proxy, then CONNECT + inner TLS to the target =
+ * TLS-over-TLS) and a plain HTTP proxy (TCP + CONNECT). With no proxy set, a
+ * direct TLS connection is made. Certificate verification is disabled because
+ * the whole point is a host whose certs the platform cannot verify; download
+ * integrity is instead checked by the caller via SHASUMS256.txt (sha256).
+ */
+'use strict';
+const tls = require('tls');
+const net = require('net');
+const fs = require('fs');
+
+function fail(msg, code) {
+  process.stderr.write(msg + '\n');
+  process.exit(code);
+}
+
+const targetArg = process.argv[2];
+const outFile = process.argv[3] || null;
+if (!targetArg) fail('usage: fetch-node.js <httpsUrl> [outFile]', 2);
+
+const target = new URL(targetArg);
+if (target.protocol !== 'https:') fail('only https URLs are supported', 2);
+
+const proxyRaw = process.env.ICLAUDE_PROXY_URL || process.env.HTTPS_PROXY || process.env.https_proxy || '';
+const proxy = proxyRaw ? new URL(proxyRaw) : null;
+
+// Open the tunnel socket to the target (through a proxy when configured).
+function openTunnel(cb) {
+  if (!proxy) {
+    // Direct: TLS straight to the target host.
+    const s = tls.connect(
+      { host: target.hostname, port: 443, servername: target.hostname, rejectUnauthorized: false },
+      () => cb(s)
+    );
+    s.on('error', (e) => fail('direct tls error: ' + e.message, 3));
+    return;
+  }
+
+  const proxyHost = proxy.hostname;
+  const proxyPort = proxy.port || (proxy.protocol === 'https:' ? 443 : 8080);
+  const proxyAuth = proxy.username
+    ? 'Proxy-Authorization: Basic ' +
+      Buffer.from(decodeURIComponent(proxy.username) + ':' + decodeURIComponent(proxy.password)).toString('base64') +
+      '\r\n'
+    : '';
+
+  const onProxyReady = (proxySock) => {
+    proxySock.write(
+      'CONNECT ' + target.hostname + ':443 HTTP/1.1\r\n' +
+      'Host: ' + target.hostname + ':443\r\n' + proxyAuth + '\r\n'
+    );
+    let header = '';
+    const onData = (chunk) => {
+      header += chunk.toString('binary');
+      if (header.indexOf('\r\n\r\n') === -1) return;
+      proxySock.removeListener('data', onData);
+      const statusLine = header.split('\r\n')[0];
+      if (!/ 200 /.test(statusLine)) fail('proxy CONNECT failed: ' + statusLine, 4);
+      // Inner TLS to the real target, layered over the proxy connection.
+      const inner = tls.connect(
+        { socket: proxySock, servername: target.hostname, rejectUnauthorized: false },
+        () => cb(inner)
+      );
+      inner.on('error', (e) => fail('inner tls error: ' + e.message, 6));
+    };
+    proxySock.on('data', onData);
+    proxySock.on('error', (e) => fail('proxy socket error: ' + e.message, 3));
+  };
+
+  if (proxy.protocol === 'https:') {
+    const s = tls.connect(
+      { host: proxyHost, port: proxyPort, servername: proxyHost, rejectUnauthorized: false },
+      () => onProxyReady(s)
+    );
+    s.on('error', (e) => fail('proxy tls error: ' + e.message, 3));
+  } else {
+    const s = net.connect(proxyPort, proxyHost, () => onProxyReady(s));
+    s.on('error', (e) => fail('proxy tcp error: ' + e.message, 3));
+  }
+}
+
+openTunnel((sock) => {
+  sock.write(
+    'GET ' + target.pathname + target.search + ' HTTP/1.1\r\n' +
+    'Host: ' + target.hostname + '\r\n' +
+    'User-Agent: iclaude-fetch\r\n' +
+    'Accept: */*\r\n' +
+    'Connection: close\r\n\r\n'
+  );
+
+  let headParsed = false;
+  let headBuf = Buffer.alloc(0);
+  let status = 0;
+  let received = 0;
+  const out = outFile ? fs.createWriteStream(outFile) : null;
+  const chunks = [];
+
+  const writeBody = (buf) => {
+    if (!buf.length) return;
+    received += buf.length;
+    if (out) out.write(buf);
+    else chunks.push(buf);
+  };
+
+  sock.on('data', (d) => {
+    if (headParsed) { writeBody(d); return; }
+    headBuf = Buffer.concat([headBuf, d]);
+    const hi = headBuf.indexOf('\r\n\r\n');
+    if (hi === -1) return;
+    const head = headBuf.slice(0, hi).toString();
+    status = parseInt(head.split('\r\n')[0].split(' ')[1], 10) || 0;
+    headParsed = true;
+    writeBody(headBuf.slice(hi + 4));
+  });
+
+  sock.on('end', () => {
+    const done = () => {
+      process.stderr.write('HTTP ' + status + ', ' + received + ' bytes' + (outFile ? ' -> ' + outFile : '') + '\n');
+      process.exit(status === 200 ? 0 : 5);
+    };
+    if (out) out.end(done);
+    else { process.stdout.write(Buffer.concat(chunks)); done(); }
+  });
+  sock.on('error', (e) => fail('read error: ' + e.message, 6));
+});


### PR DESCRIPTION
## Problem

Claude Code `2.1.199` requires **Node >=22** (`engines.node`), but the isolated env ran **Node 20**. `--update` emitted `npm warn EBADENGINE` and installed a Claude Code that may not run correctly.

Root cause dug out on a real host: nvm's `nvm install 22` failed with `Version '22' not found` because system `curl`/OpenSSL cannot complete a TLS handshake to `nodejs.org` — `x509_pubkey_decode:unsupported algorithm` (AltLinux GOST-patched OpenSSL / TLS-intercepting proxy), failing **even with `-k` and even bypassing the proxy**. `npm` keeps working only because Node bundles its own OpenSSL.

## Changes

- **`ensure_isolated_node_engine`** (`lib/nvm/install.sh`): reads `npm view <pkg> engines.node`; if the active Node major is too old, **offers** (prompt, default yes) to install the required major inside the isolated nvm. Runs even when Claude Code is already latest.
- **`update_claude_code`** (`lib/update/update.sh`): **aborts** when Node can't be upgraded (declined or download failed) instead of installing an unrunnable Claude Code.
- **`fetch_node_via_node_tls` + `scripts/fetch-node.js`**: fallback installer that downloads the Node tarball using **Node's own TLS stack** (TLS-over-TLS through the HTTPS proxy, or direct), verifies it against `SHASUMS256.txt` (sha256), and extracts into `versions/node/`. `install_isolated_nodejs` uses the same fallback, so **`--update` and `--isolated-install` self-heal**; the fetcher can bootstrap from a system Node when the isolated env has none.
- **Default Node bumped `20` → `22`** (`install_isolated_nodejs`, lockfile-install fallback).

Global packages live in the shared `npm-global` prefix, so they survive a Node switch — no `--reinstall-packages-from` migration.

## Verification

- Installed Node **v22.23.1** into the isolated env via the node-TLS path; SHA256 verified; `claude --version` → `2.1.199` clean, no `EBADENGINE`; `--check-isolated` reports `Node.js: v22.23.1` healthy.
- End-to-end test of `fetch_node_via_node_tls` in a throwaway `NVM_DIR` (resolve → download → verify → extract), bootstrapping from system Node.
- `bash -n` clean on all edited scripts.

## Docs

iwiki `overview.md` (Isolated Environment) and `README.md` updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)