### PR TITLE
docs(ledger): adopt the 2026-08-13 task-ledger revision

### DIFF
--- a/.nvm-isolated/.claude-isolated/CLAUDE.md
+++ b/.nvm-isolated/.claude-isolated/CLAUDE.md
@@ -37,7 +37,7 @@ Skip only when: familiar area, same session.
   - **Existing page** → `wiki_update_page(domain, slug, heading, new_body, source=<changed-source>)`. Rewrites one `##` section in place.
   - **Stale / removed source** → `wiki_delete_page(domain, slug)`. Drops the page and its vectors.
 - Call `wiki_index(domain)` only to rebuild after out-of-band edits (markdown changed on disk without a tool) or a sync conflict — never as a routine step after a write.
-- Run `wiki_lint` — no broken `[[refs]]`, no orphan or stale pages.
+- Run `wiki_lint` — no broken `[[refs]]`, no orphan or stale pages. Task pages (`reference/tasks/*`) and their history segments (`reference/task-history/*`) are exempt from the orphan check by design.
 - Writes auto-commit the base locally; `wiki_sync` publishes those commits to the git remote (pull-rebase-push) — run it only when sharing the base across machines.
 - Skip only for changes that touch no functionality, architecture, or behavior (typo, comment, formatting).
 
@@ -61,15 +61,17 @@ These files are the entry point for two audiences at once: business users who ne
 
 Bounded discovery comes first and creates nothing: read the request, the project binding, and the minimum repository context needed to derive the domain, the `<topic>`, and the route. Then open the page — before analysing the task itself.
 
-- **Preconditions.** Call `wiki_status`. Write to `primary`. If no domain is bound, `wiki_bind(read=[<domain>], write=[<domain>])`. If the server is unreachable, say `Tracking: unavailable`, spool the events, continue working — but the task cannot reach `done`.
+- **Preconditions.** Call `wiki_status`. Write to `primary`. If no domain is bound, `wiki_bind(read=[<domain>], write=[<domain>])`. If the server is unreachable, say `Tracking: unavailable`, spool the redacted events to `$CLAUDE_CONFIG_DIR/state/iwiki-task-spool/<project>/<topic>.json`, continue working — but the task cannot reach `done`.
 - **One page per topic**, slug `reference/tasks/<topic>`, frontmatter passed as tool parameters only: `type: reference`, `status: stable`, `tags: [task, <topic>, workflow:<direct|chain|loen>]`. Never put frontmatter inline in `markdown` — the server duplicates it and `wiki_lint` blocks on `pre_h2_text`.
-- **No index page, no changelog page.** Project status is derived by enumerating task pages with `wiki_list_pages(domain)` filtered to the `reference/tasks/` prefix; use `wiki_search(query=..., tags=["task"])` only for content lookup within a topic.
+- **No index page.** Project status is derived by enumerating task pages with `wiki_list_pages(domain)` filtered to the `reference/tasks/` prefix; use `wiki_search(query=..., tags=["task"])` only for content lookup within a topic.
+- **Domain changelog** at `reference/domain-changelog` records only material domain-level changes — standards, releases, migrations, cross-task decisions — each linking to the relevant task page. It is not a task index and never repeats routine task events.
 - **Five `##` sections, each once, never renamed or reordered**: `Current State`, `TODO`, `Subtasks`, `Evidence`, `Changelog`. No `###`. Each section opens with a lead of at most 250 characters, then a blank line.
+- **History segments.** The event history lives in `reference/task-history/<topic>-<sequence>` pages, same frontmatter as the task page, two `##` sections: `Events` (at most 20, ordered, oldest first) and `Next` (the successor slug, or `none`). `Changelog` on the task page is a manifest only — first segment, active segment, event count. A new event rewrites the active segment alone; at 20 events open `<topic>-<sequence+1>` and point `Next` at it. Replay traverses the segment chain to load durable keys before appending.
 - **Lifecycle** in the body: `in-progress`, `blocked`, `completion-pending`, `done`.
 - **Single writer.** Only the parent agent writes. Subagents are read-only against the wiki (`wiki_search`, `wiki_read_page`, `wiki_related`) and return structured evidence — subtask id, role, outcome, changed paths, checks, blockers, proposed changelog text — which the parent records. Hooks never reach MCP; loop hooks write `docs/loen/<topic>/` and the parent mirrors loop state at four material stage boundaries: loop start (plan approved, `loop.yaml` armed) → `open`/`route`; each `loop-check` verdict → `verification`; each `loop-reflect` decision of `fix`, `revert`, or `handoff` → `decision`/`blocker`; the terminal `7_result.md` or `handoff.md` → `close`. Per-iteration act steps and hook-rendered `audit.html` refreshes are not mirrored.
 - **Write points.** `open` before any task-specific analysis or implementation, after bounded discovery only; `route` when the workflow or model route is decided; `verification` at each `/check-chain` verdict or loop-check; `dispatch` before delegating and `return` when the subagent answers; `blocker` when blocked; `close` at the end. Tool calls are not events.
-- **Idempotency.** Every `Changelog` entry carries `key:` = `sha256(topic \n kind \n canonical redacted evidence)` truncated to 12 chars. Timestamp, actor, and the human-readable summary must not enter the key — otherwise a replay of the same fact appends a duplicate. An entry whose key is present is not appended again. Entries are append-only; rewriting one is proposal-first and only to repair malformed or secret-bearing content.
-- **Close is fail-closed.** `done` requires final evidence recorded, every spooled event delivered, and `wiki_lint` reporting no new finding for the page. Until then the task stays `completion-pending`.
+- **Idempotency.** Every segment event carries `key:` = `sha256(topic \n kind \n canonical redacted evidence)` truncated to 12 chars. Timestamp, actor, and the human-readable summary must not enter the key — otherwise a replay of the same fact appends a duplicate. An event whose key is present anywhere in the segment chain is not appended again. Entries are append-only; rewriting one is proposal-first and only to repair malformed or secret-bearing content.
+- **Close is fail-closed.** `done` requires final evidence recorded, every spooled event delivered, and `wiki_lint` reporting no new finding for the task page or its segments. An `orphan` entry for `reference/tasks/*` or `reference/task-history/*` is the expected advisory — refusing a central index leaves those pages unreachable by link — and never blocks closure; any other finding does. Until then the task stays `completion-pending`.
 - **Divergence** from the shared standard is recorded on `devops/concept/wiki-task-ledger` before it is implemented.
 
 ## Task Topic
@@ -83,6 +85,7 @@ Bounded discovery comes first and creates nothing: read the request, the project
   - LoEn topic directory `docs/loen/<topic>/`, for LoEn loop work;
   - git branch suffix: `dev-<topic>`.
 - Do not use vague topics such as `fix`, `update`, `work`, `misc`, `phase1`, or `changes`.
+- Do not start a topic with `task`: the topic becomes a wiki tag next to the base tag `task`, and `wiki_lint` reports the pair as `tag_drift`.
 - Prefer topics that describe the task domain and intended outcome, not just the implementation step.
 - If a branch already exists, derive `<topic>` from the branch suffix unless it is vague.
 - If controlled artifacts (task page slug, chain/LoEn topic, branch name) disagree, stop and normalize them to one `<topic>` before continuing.
@@ -338,11 +341,11 @@ Switch confirmation: n/a | pending | confirmed | declined
 **When the user asks for project status, progress, or "what's the state of X", build the answer from two sources together — never one alone: the project's task pages (what is being worked on) and the project's subject-matter wiki pages (what is documented as true).**
 
 - **Read both first.** Call `wiki_status`; then `wiki_list_pages(domain)` filtered to the `reference/tasks/` prefix for the full set of task pages, and `wiki_search(query=...)` / `wiki_read_page` for the topic's subject-matter pages. If iwiki is unavailable, say so — there is no in-repo fallback.
-- **Report shape:** lead with overall state (counts by lifecycle, or the specific topic's `Current State`), then per-topic detail (the `TODO` stages and the latest `Changelog` events), then a **Discrepancies** section.
+- **Report shape:** lead with overall state (counts by lifecycle, or the specific topic's `Current State`), then per-topic detail (the `TODO` stages and the latest events from the active history segment named in `Changelog`), then a **Discrepancies** section.
 - **Reconcile the two sources and surface every mismatch.** Examples of discrepancies to flag:
   - A task page is `done` but the wiki has no subject-matter page (or a stale one) covering it.
   - The wiki documents a feature/behavior that has no matching task page.
-  - A task page records a passed stage but the subject-matter page still describes the old behavior, or `wiki_lint` flags it stale/orphan.
+  - A task page records a passed stage but the subject-matter page still describes the old behavior, or `wiki_lint` flags it stale. An `orphan` entry for a task or history page is expected by design, not a discrepancy.
   - Lifecycle, dates, or scope disagree between the two.
   - A task page sits at `completion-pending` with events still spooled.
 - **No silent reconciliation.** Report discrepancies; do not fix the task page or the subject-matter page as a side effect of a status request. If none exist, state "task pages and documentation agree" explicitly.

--- a/.nvm-isolated/.claude-isolated/skills/check-chain/SKILL.md
+++ b/.nvm-isolated/.claude-isolated/skills/check-chain/SKILL.md
@@ -132,9 +132,10 @@ Task Log convention in `CLAUDE.md`). If the page is absent, create it with
 `wiki_write_page` and the five required sections; otherwise `wiki_read_page` the
 section you are about to change, then `wiki_update_page` it in full.
 
-- Append one `verification` event to `Changelog`: `- <today> — verification — <stage> <verdict> — key:<key>`, where `<key>` is derived from topic, event kind, and a hash of the recorded evidence. Skip the append when that key is already present.
+- Append one `verification` event to the `Events` section of the active history segment named in `Changelog` — `reference/task-history/<topic>-<sequence>`, created with the same frontmatter when absent: `- <today> — verification — <stage> <verdict> — key:<key>`, where `<key>` is derived from topic, event kind, and a hash of the recorded evidence. Skip the append when that key is already present in the segment chain. At 20 events open the next segment and point the current one's `Next` at it.
+- Refresh the `Changelog` manifest on the task page (first segment, active segment, event count) — never copy the events themselves there.
 - Tick the stage's line in `TODO`.
-- On `result` `OK`: set `Current State` `Lifecycle: done` and `Closed: <today>`, and append the `close` event — but only after every queued event is delivered and `wiki_lint` reports no new finding for the page. Otherwise set `Lifecycle: completion-pending`.
+- On `result` `OK`: set `Current State` `Lifecycle: done` and `Closed: <today>`, and append the `close` event — but only after every queued event is delivered and `wiki_lint` reports no new finding for the task page or its segments, the expected `orphan` advisory for `reference/tasks/*` and `reference/task-history/*` aside. Otherwise set `Lifecycle: completion-pending`.
 - If the MCP server is unreachable, append the event to the spool at `$CLAUDE_CONFIG_DIR/state/iwiki-task-spool/<project>/<topic>.json`, report `Tracking: unavailable`, and continue — the stage verdict itself is never blocked by the wiki channel.
 
 ## Rules (prohibited)

--- a/docs/superpowers/plans/2026-08-12-wiki-task-ledger-plan.md
+++ b/docs/superpowers/plans/2026-08-12-wiki-task-ledger-plan.md
@@ -3,7 +3,7 @@ chain:
   intent: docs/superpowers/intents/2026-08-12-wiki-task-ledger-intent.md
   intent_hash: 744c651c66a47cc1
   spec: docs/superpowers/specs/2026-08-12-wiki-task-ledger-design.md
-  spec_hash: 0720846c7cecf25a
+  spec_hash: 4da5c5a3e050ded0
 result_check:
   verdict: OK
   plan_hash: 15eac6a739017179

--- a/docs/superpowers/specs/2026-08-12-wiki-task-ledger-design.md
+++ b/docs/superpowers/specs/2026-08-12-wiki-task-ledger-design.md
@@ -3,8 +3,8 @@ chain:
   intent: docs/superpowers/intents/2026-08-12-wiki-task-ledger-intent.md
   intent_hash: 744c651c66a47cc1
 review:
-  spec_hash: 0720846c7cecf25a
-  last_run: 2026-08-12
+  spec_hash: 4da5c5a3e050ded0
+  last_run: 2026-08-13
   phases:
     structure:
       status: passed
@@ -54,7 +54,7 @@ Desired Outcomes carried verbatim:
 
 Done when: `docs/TODO.md` is deleted and its rows survive as one archive page;
 `check-chain` Step 6 and the LoEn hooks no longer write to `docs/TODO.md`; every
-open topic has a `reference/tasks/<topic>` page discoverable by tag search;
+open topic has a `reference/tasks/<topic>` page discoverable without an index;
 `wiki_lint` reports no new task-page finding. Orphan entries for
 `reference/tasks/*` are expected: refusing a central index is what leaves task
 pages unreachable by link.
@@ -63,7 +63,9 @@ pages unreachable by link.
 
 The ledger is one page per topic in the project's **primary** write domain.
 There is no index page and no changelog page: per-topic pages are the only task
-state, and status is derived by searching pages tagged `task`.
+state, and status is derived by enumerating the `reference/tasks/` prefix with
+`wiki_list_pages`; `wiki_search(tags=["task"])` serves content lookup within a
+topic.
 
 ```
 parent agent ──wiki_read_page──►  reference/tasks/<topic>
@@ -265,7 +267,7 @@ Markdown is shown to the user before the file is removed.
 
 | File | Change |
 |---|---|
-| `CLAUDE.md` | `Task Log (docs/TODO.md)` → `Task Log (iwiki)`, covering direct work too; in `Task Topic`, the controlled surface `docs/TODO.md` `Topic` → slug `reference/tasks/<topic>`; `Project Status Reports` derives status by tag search and reconciles it against the domain's subject-matter pages |
+| `CLAUDE.md` | `Task Log (docs/TODO.md)` → `Task Log (iwiki)`, covering direct work too; in `Task Topic`, the controlled surface `docs/TODO.md` `Topic` → slug `reference/tasks/<topic>`; `Project Status Reports` derives status by enumerating the `reference/tasks/` prefix with `wiki_list_pages` and reconciles it against the domain's subject-matter pages |
 | `skills/check-chain/SKILL.md` | Step 6 becomes MCP calls against the topic page; "TODO cell" / "TODO upsert" wording in the run modes and stage profiles follows |
 | `plugin/loen/hooks/loen_artifacts.py` | drop `upsert_todo_row`, `_TODO_HEADER`, `_TODO_SEP`, `_LOEN_NOTE`, `_row_cells`; fix the module docstring |
 | `plugin/loen/hooks/audit-writer.py` | drop the call and the docstring mention |
@@ -292,24 +294,32 @@ Automated:
 
 Manual, because ledger behavior lives in rules rather than code:
 
-- `wiki_search(tags=["task"])` returns the three migrated topic pages plus the
-  archive page — status is derivable without an index.
+- `wiki_list_pages(<primary>)` filtered to the `reference/tasks/` prefix returns
+  the three migrated topic pages plus the archive page — status is derivable
+  without an index.
 - `wiki_lint` reports no new task-page finding: no `pre_h2_text`, no `long_lead`
   on task pages, no broken refs, nothing stale. Orphan entries for
   `reference/tasks/*` are expected, not defects — refusing a central index is
-  what makes task pages unreachable by link, and status comes from tag search
-  instead. This wording matches the shared standard's own completion criterion.
+  what makes task pages unreachable by link, and status comes from prefix
+  enumeration instead. This wording matches the shared standard's own completion
+  criterion.
 - A simulated outage leaves the task `completion-pending`, and a replay after
   recovery adds no duplicate `Changelog` entry (idempotency keys hold).
 
 ## 9. Divergence from the shared standard
 
-One recorded, the rest are refinements.
+Two recorded, the rest are refinements.
 
 **Recorded on the shared page:** the spool lives under `$CLAUDE_CONFIG_DIR`
 rather than `$CODEX_HOME`, because the harness differs. The standard's
 `Ordering and degradation` section now names both homes, so an `icodex` agent
 reading it will not treat the `iclaude` path as drift.
+
+**Recorded on the shared page:** status derivation enumerates the
+`reference/tasks/` prefix with `wiki_list_pages` instead of the standard's tag
+search. Enumeration is exhaustive and deterministic, while `wiki_search` ranks
+and truncates; `wiki_search(tags=["task"])` is kept for content lookup within a
+topic. The standard's `Decision` section names both calls.
 
 **Refinements, not departures:** the enumerated material stage boundaries in §5,
 the migration shape in §6, and the archive page's pointer to the pre-deletion

--- a/plugin/loen/skills/loop-check/SKILL.md
+++ b/plugin/loen/skills/loop-check/SKILL.md
@@ -27,6 +27,7 @@ verdict. You never approve your own work.
 Report the gate result (`PASS`/`FAIL`), the verifier `VERDICT`, and that `loop-reflect`
 decides next. Both the gates and the verifier must agree before the loop can terminate.
 
-The parent (never this hook) records a `verification` event on the topic's wiki task page
-`reference/tasks/<topic>` with the gate result and verifier `VERDICT` — this is a material
+The parent (never this hook) records a `verification` event in the topic's active history
+segment `reference/task-history/<topic>-<sequence>`, linked from the task page
+`reference/tasks/<topic>`, with the gate result and verifier `VERDICT` — this is a material
 stage boundary per the Task Log rule.

--- a/plugin/loen/skills/loop-reflect/SKILL.md
+++ b/plugin/loen/skills/loop-reflect/SKILL.md
@@ -47,7 +47,8 @@ Report the decision and the terminal artifact written (`7_result.md` for Done, `
 for a human decision). Never declare Done without gates `PASS` + verifier `APPROVE` + evidence
 (the evidence-gate Stop hook enforces this).
 
-The parent (never this hook) records the corresponding event on the topic's wiki task page
+The parent (never this hook) records the corresponding event in the topic's active history
+segment `reference/task-history/<topic>-<sequence>`, linked from the task page
 `reference/tasks/<topic>`: a `decision`/`blocker` event for `fix`, `revert`, or `handoff`, and
 a `close` event when `7_result.md` or `handoff.md` is the terminal artifact — these are
 material stage boundaries per the Task Log rule.


### PR DESCRIPTION
## Summary

Syncs iclaude with the three rules the shared standard `devops/concept/wiki-task-ledger` gained on 2026-08-13, after PR #91 was merged:

- **History segments** — material events now live in `reference/task-history/<topic>-<sequence>` pages (`Events` up to 20, then `Next`); the task page's `Changelog` is a manifest naming the first segment, the active segment, and the event count.
- **Domain changelog** — `reference/domain-changelog` records material domain-level changes only; the previous blanket "no changelog page" rule is gone.
- **Orphan advisory** — an `orphan` entry for a task or history page is expected by design and never blocks closure; any other finding still does.

Also records the spool path in the Task Log preconditions, and forbids topics starting with `task` (they collide with the base `task` tag and produce `wiki_lint` `tag_drift` — hit while doing this task, topic renamed).

Hooks are unchanged by design: they never reach MCP, so the ledger has no hook surface.

## Changed

- `.nvm-isolated/.claude-isolated/CLAUDE.md` — Task Log, Task Topic, Keep Docs Current, Project Status Reports
- `.nvm-isolated/.claude-isolated/skills/check-chain/SKILL.md` — Step 6 writes the event to the active segment and refreshes the manifest
- `plugin/loen/skills/loop-check/SKILL.md`, `plugin/loen/skills/loop-reflect/SKILL.md` — mirroring target is the active segment

## Verification

- `python3 tests/test_loen_artifacts.py` → exit 0
- `python3 tests/test_loen_audit_writer.py` → exit 0
- `bash tests/test_loen_plugin.sh` → exit 0
- `wiki_lint(iclaude)` → `broken: []`, no new finding beyond the expected task-page orphan advisory
- Ledger for this task dogfoods the new shape: `reference/tasks/ledger-history-segments` + `reference/task-history/ledger-history-segments-1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)