### PR TITLE
feat(iwiki): refresh the iwiki MCP configuration surface

### DIFF
--- a/.claude_config.example
+++ b/.claude_config.example
@@ -807,6 +807,16 @@ ICLAUDE_DEBUG_LAUNCH=
 # The server is only registered when IWIKI_LLM_KEY is set and `iwiki-mcp`
 # resolves on PATH.
 #
+# Two modes. REMOTE talks to a hosted `iwiki-mcp serve --transport
+# streamable-http` over HTTP and needs no local binary, no wiki base, and no
+# embeddings key — the server owns storage and credentials, and the bearer token
+# selects the wiki plus its read/write grants. Setting the URL is the opt-in, so
+# remote wins over a local install when both are configured:
+# ICLAUDE_IWIKI_REMOTE_URL="https://iwiki.example/mcp"   # must end at the /mcp endpoint
+# ICLAUDE_IWIKI_REMOTE_TOKEN="..."                       # bearer token (secret — keep here, not in git)
+#
+# Everything below configures the LOCAL (stdio) mode instead.
+#
 # Required (server halts without these):
 # ICLAUDE_IWIKI_BASE_DIR="/home/user/wiki"          # shared wiki base dir
 # ICLAUDE_IWIKI_LLM_BASE_URL="https://.../v1"        # OpenAI-compatible embeddings endpoint

--- a/.claude_config.example
+++ b/.claude_config.example
@@ -848,10 +848,15 @@ ICLAUDE_DEBUG_LAUNCH=
 # ICLAUDE_IWIKI_SEED_THRESHOLD="0.15"                # minimum seed similarity for a read
 # ICLAUDE_IWIKI_WRITE_SEED_THRESHOLD="0.35"          # stricter seed similarity for intent="write"
 #
-# NOT configured here: the optional Python code graph. Its IWIKI_CODE_GRAPH_*
-# variables override the project's .iwiki.toml [code_graph] table, so iclaude
-# deliberately does not forward them — a default injected at launch would make
-# every per-project setting unreachable. Configure [code_graph] in .iwiki.toml.
+# Python code graph (optional; wiki_code_index / wiki_code_search / wiki_code_context).
+# Its home is the project's .iwiki.toml [code_graph] table — the server applies
+# these variables AFTER that table, so anything set here overrides EVERY project
+# you open with iclaude. Leave them unset unless you want exactly that; when
+# unset, iclaude forwards nothing and .iwiki.toml stays authoritative.
+# ICLAUDE_IWIKI_CODE_GRAPH_ENABLED="true"            # true | false (exact strings)
+# ICLAUDE_IWIKI_CODE_GRAPH_AUTO_REBUILD="bounded"    # bounded | off
+# ICLAUDE_IWIKI_CODE_GRAPH_MAX_FILE_BYTES="1000000"
+# ICLAUDE_IWIKI_CODE_GRAPH_MAX_FILES="20000"
 #
 # Optional: override the binary path (default: resolved via `command -v iwiki-mcp`):
 # ICLAUDE_IWIKI_COMMAND=/path/to/iwiki-mcp

--- a/.claude_config.example
+++ b/.claude_config.example
@@ -812,17 +812,46 @@ ICLAUDE_DEBUG_LAUNCH=
 # ICLAUDE_IWIKI_LLM_BASE_URL="https://.../v1"        # OpenAI-compatible embeddings endpoint
 # ICLAUDE_IWIKI_LLM_KEY="..."                        # embeddings API key (secret — keep here, not in git)
 #
+# PostgreSQL storage (only when the project's .iwiki.toml declares
+# [storage] type = "postgres"; every other field lives in that TOML file):
+# ICLAUDE_IWIKI_DB_PASSWORD="..."                    # database password (secret — keep here, not in git)
+#
 # Embedding model (defaults shown; EMBED_DIMENSIONS must match the model):
 # ICLAUDE_IWIKI_EMBED_MODEL="text-embedding-3-small"
 # ICLAUDE_IWIKI_EMBED_DIMENSIONS="1536"
 #
-# Search / indexing tuning (optional; server defaults apply when unset):
+# Chat model (optional; empty disables it). When set, the server classifies
+# `type`/`tags` frontmatter itself, reusing LLM_BASE_URL / LLM_KEY:
+# ICLAUDE_IWIKI_CHAT_MODEL="..."
+#
+# Reranker (optional; empty disables it). Reuses LLM_BASE_URL / LLM_KEY and
+# fails soft, so a missing model degrades to the unreranked result order:
+# ICLAUDE_IWIKI_RERANK_MODEL="..."
+#
+# Server lifecycle: seconds of MCP inactivity after which the stdio server
+# exits; 0 disables the limit. A later call reconnects and respawns it:
+# ICLAUDE_IWIKI_IDLE_TIMEOUT_SECONDS="86400"
+#
+# Indexing tuning (optional; server defaults apply when unset):
 # ICLAUDE_IWIKI_CHUNK_SIZE="512"
 # ICLAUDE_IWIKI_CHUNK_OVERLAP="64"
 # ICLAUDE_IWIKI_SUMMARY_MAX_CHARS="400"
+#
+# Search tuning (optional; server defaults apply when unset). SEARCH_MODE is
+# only the default for an omitted wiki_search(mode=...); an explicit mode wins:
+# ICLAUDE_IWIKI_SEARCH_MODE="hybrid"                 # hybrid | lexical | semantic
 # ICLAUDE_IWIKI_TOP_K="8"
 # ICLAUDE_IWIKI_SCORE_THRESHOLD="0.2"
 # ICLAUDE_IWIKI_GRAPH_DEPTH="2"
+# ICLAUDE_IWIKI_SEED_TOP_K="5"                       # articles seeded before graph expansion
+# ICLAUDE_IWIKI_BFS_TOP_K="10"                       # cap on graph-expanded articles
+# ICLAUDE_IWIKI_SEED_THRESHOLD="0.15"                # minimum seed similarity for a read
+# ICLAUDE_IWIKI_WRITE_SEED_THRESHOLD="0.35"          # stricter seed similarity for intent="write"
+#
+# NOT configured here: the optional Python code graph. Its IWIKI_CODE_GRAPH_*
+# variables override the project's .iwiki.toml [code_graph] table, so iclaude
+# deliberately does not forward them — a default injected at launch would make
+# every per-project setting unreachable. Configure [code_graph] in .iwiki.toml.
 #
 # Optional: override the binary path (default: resolved via `command -v iwiki-mcp`):
 # ICLAUDE_IWIKI_COMMAND=/path/to/iwiki-mcp

--- a/.gitignore
+++ b/.gitignore
@@ -93,6 +93,8 @@ scripts/.claude_proxy_credentials  # Legacy
 !.nvm-isolated/.claude-isolated/CHANGELOG-v7.0.md
 !.nvm-isolated/.claude-isolated/mcp/
 !.nvm-isolated/.claude-isolated/mcp/**
+# Launch-time render of mcp/iwiki.json (adds the optional code-graph keys)
+.nvm-isolated/.claude-isolated/mcp/*.runtime.json
 !.nvm-isolated/.claude-isolated/settings.json
 !.nvm-isolated/.claude-isolated/hooks/
 !.nvm-isolated/.claude-isolated/hooks/**

--- a/.iwiki.toml
+++ b/.iwiki.toml
@@ -1,3 +1,45 @@
+# iwiki project binding. Read by the iwiki MCP server from the project root.
+# `wiki_bind` rewrites the four core keys below and preserves everything else,
+# so these comments and the commented examples survive a rebind.
+#
+# read    — default project search scope. Empty or absent means "every domain in
+#           the base"; ["all"] is a literal domain named `all`, not a wildcard.
+# write   — domains mutating tools may change. Must be a subset of `read`.
+# primary — default target for wiki_index / wiki_write_page. Must be in `write`.
+# base    — optional; overrides IWIKI_BASE_DIR for this project only:
+# base = "/home/user/wiki"
+
 read = ["iclaude", "icodex", "iwiki-mcp", "devops"]
 write = ["iclaude" ,"devops"]
 primary = "iclaude"
+
+# Optional Python code graph (wiki_code_index / wiki_code_search /
+# wiki_code_context). All fields are optional; the values shown are the
+# defaults. `languages` accepts only "python". `exclude` takes safe relative
+# paths. The cache is local, under <IWIKI_BASE_DIR>/.iwiki/, and is never built
+# at server startup. The ICLAUDE_IWIKI_CODE_GRAPH_* variables in .claude_config
+# override this table for every project, so prefer configuring it here.
+#
+# [code_graph]
+# enabled = true
+# languages = ["python"]
+# auto_rebuild = "bounded"          # bounded | off
+# max_rebuild_seconds = 10
+# max_file_bytes = 1000000
+# max_total_files = 20000
+# include_tests = true
+# exclude = []
+
+# Optional PostgreSQL storage instead of the default Git base. Requires
+# non-empty `read`/`write` and a `primary`; the wiki and its domains must
+# already exist. The password comes from ICLAUDE_IWIKI_DB_PASSWORD, never from
+# this file. Omit the whole table for Git storage.
+#
+# [storage]
+# type = "postgres"
+# host = "db.internal.example"
+# port = 5432
+# database = "iwiki"
+# user = "iwiki_app"
+# sslmode = "verify-full"
+# iwiki_id = "team-wiki"            # local stdio only; a hosted server rejects it

--- a/.nvm-isolated/.claude-isolated/mcp/iwiki-remote.json
+++ b/.nvm-isolated/.claude-isolated/mcp/iwiki-remote.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "iwiki": {
+      "type": "http",
+      "url": "${IWIKI_REMOTE_URL}",
+      "headers": {
+        "Authorization": "Bearer ${IWIKI_REMOTE_TOKEN}"
+      }
+    }
+  }
+}

--- a/.nvm-isolated/.claude-isolated/mcp/iwiki.json
+++ b/.nvm-isolated/.claude-isolated/mcp/iwiki.json
@@ -5,17 +5,26 @@
       "command": "${IWIKI_COMMAND}",
       "args": [],
       "env": {
-        "IWIKI_BASE_DIR":          "${IWIKI_BASE_DIR}",
-        "IWIKI_LLM_BASE_URL":      "${IWIKI_LLM_BASE_URL}",
-        "IWIKI_LLM_KEY":           "${IWIKI_LLM_KEY}",
-        "IWIKI_EMBED_MODEL":       "${IWIKI_EMBED_MODEL:-text-embedding-3-small}",
-        "IWIKI_EMBED_DIMENSIONS":  "${IWIKI_EMBED_DIMENSIONS:-1536}",
-        "IWIKI_CHUNK_SIZE":        "${IWIKI_CHUNK_SIZE:-512}",
-        "IWIKI_CHUNK_OVERLAP":     "${IWIKI_CHUNK_OVERLAP:-64}",
-        "IWIKI_SUMMARY_MAX_CHARS": "${IWIKI_SUMMARY_MAX_CHARS:-400}",
-        "IWIKI_TOP_K":             "${IWIKI_TOP_K:-8}",
-        "IWIKI_SCORE_THRESHOLD":   "${IWIKI_SCORE_THRESHOLD:-0.2}",
-        "IWIKI_GRAPH_DEPTH":       "${IWIKI_GRAPH_DEPTH:-2}"
+        "IWIKI_BASE_DIR":             "${IWIKI_BASE_DIR}",
+        "IWIKI_LLM_BASE_URL":         "${IWIKI_LLM_BASE_URL}",
+        "IWIKI_LLM_KEY":              "${IWIKI_LLM_KEY}",
+        "IWIKI_DB_PASSWORD":          "${IWIKI_DB_PASSWORD:-}",
+        "IWIKI_EMBED_MODEL":          "${IWIKI_EMBED_MODEL:-text-embedding-3-small}",
+        "IWIKI_EMBED_DIMENSIONS":     "${IWIKI_EMBED_DIMENSIONS:-1536}",
+        "IWIKI_CHAT_MODEL":           "${IWIKI_CHAT_MODEL:-}",
+        "IWIKI_RERANK_MODEL":         "${IWIKI_RERANK_MODEL:-}",
+        "IWIKI_IDLE_TIMEOUT_SECONDS": "${IWIKI_IDLE_TIMEOUT_SECONDS:-86400}",
+        "IWIKI_CHUNK_SIZE":           "${IWIKI_CHUNK_SIZE:-512}",
+        "IWIKI_CHUNK_OVERLAP":        "${IWIKI_CHUNK_OVERLAP:-64}",
+        "IWIKI_SUMMARY_MAX_CHARS":    "${IWIKI_SUMMARY_MAX_CHARS:-400}",
+        "IWIKI_SEARCH_MODE":          "${IWIKI_SEARCH_MODE:-hybrid}",
+        "IWIKI_TOP_K":                "${IWIKI_TOP_K:-8}",
+        "IWIKI_SCORE_THRESHOLD":      "${IWIKI_SCORE_THRESHOLD:-0.2}",
+        "IWIKI_GRAPH_DEPTH":          "${IWIKI_GRAPH_DEPTH:-2}",
+        "IWIKI_SEED_TOP_K":           "${IWIKI_SEED_TOP_K:-5}",
+        "IWIKI_BFS_TOP_K":            "${IWIKI_BFS_TOP_K:-10}",
+        "IWIKI_SEED_THRESHOLD":       "${IWIKI_SEED_THRESHOLD:-0.15}",
+        "IWIKI_WRITE_SEED_THRESHOLD": "${IWIKI_WRITE_SEED_THRESHOLD:-0.35}"
       }
     }
   }

--- a/lib/iwiki/mcp.sh
+++ b/lib/iwiki/mcp.sh
@@ -45,3 +45,52 @@ iwiki_mcp_enabled() {
     [[ -f "$(iwiki_mcp_config_file)" ]]      || return 1
     return 0
 }
+
+# Code-graph variables the iwiki-mcp server reads. They are NOT part of the
+# tracked config: iwiki-mcp applies them AFTER the project's `.iwiki.toml`
+# [code_graph] table, so a placeholder with a baked-in default would override
+# every project's own setting. Claude Code passes an unresolved `${VAR:-}` as a
+# set-but-empty value, and the server rejects an empty value for each of these,
+# so they can only be forwarded when actually configured.
+_IWIKI_CODE_GRAPH_VARS=(
+    IWIKI_CODE_GRAPH_ENABLED IWIKI_CODE_GRAPH_AUTO_REBUILD
+    IWIKI_CODE_GRAPH_MAX_FILE_BYTES IWIKI_CODE_GRAPH_MAX_FILES
+)
+
+# Emit one JSON `"NAME": "${NAME}",` line per code-graph var that is set to a
+# non-empty value. Empty output means "nothing to add" — the caller then uses
+# the tracked config unchanged and `.iwiki.toml` stays authoritative.
+_iwiki_code_graph_env_lines() {
+    local var
+    for var in "${_IWIKI_CODE_GRAPH_VARS[@]}"; do
+        [[ -n "${!var:-}" ]] && printf '        "%s": "${%s}",\n' "$var" "$var"
+    done
+    return 0
+}
+
+# Print the config path to hand to `--mcp-config`.
+# Without configured code-graph vars this is the tracked file itself. With them,
+# a sibling *.runtime.json is rendered by splicing the extra keys into the `env`
+# object; it holds only `${VAR}` placeholders, so it stays secret-free like the
+# tracked original (it is git-ignored because it is machine-specific). Any write
+# or render failure falls back to the tracked file — iwiki still starts, only
+# without the code-graph overrides.
+iwiki_mcp_launch_config() {
+    local tracked lines runtime
+    tracked="$(iwiki_mcp_config_file)"
+    lines="$(_iwiki_code_graph_env_lines)"
+    if [[ -z "$lines" ]]; then
+        printf '%s' "$tracked"
+        return 0
+    fi
+    runtime="${tracked%.json}.runtime.json"
+    if awk -v ins="$lines" '
+        { print }
+        /"env"[[:space:]]*:[[:space:]]*\{/ && !spliced { printf "%s", ins; spliced = 1 }
+    ' "$tracked" > "$runtime" 2>/dev/null; then
+        printf '%s' "$runtime"
+    else
+        rm -f "$runtime" 2>/dev/null || true
+        printf '%s' "$tracked"
+    fi
+}

--- a/lib/iwiki/mcp.sh
+++ b/lib/iwiki/mcp.sh
@@ -19,6 +19,26 @@ iwiki_mcp_config_file() {
     printf '%s' "${CLAUDE_CONFIG_DIR:-${ISOLATED_CONFIG_DIR:-}}/mcp/iwiki.json"
 }
 
+# Absolute path to the tracked config for a hosted (Streamable HTTP) server.
+# Remote mode talks to `iwiki-mcp serve --transport streamable-http` over
+# `type: "http"`, so it needs no local binary and no local wiki base: the URL
+# (which must end in the server's /mcp endpoint) plus a bearer token are the
+# whole client contract. Embedding credentials and storage stay server-side.
+iwiki_mcp_remote_config_file() {
+    printf '%s' "${CLAUDE_CONFIG_DIR:-${ISOLATED_CONFIG_DIR:-}}/mcp/iwiki-remote.json"
+}
+
+# True when remote mode is both requested and usable: an explicit URL, a token
+# to authenticate with, and the tracked remote config present. Setting the URL
+# is the deliberate opt-in, so remote wins over a local install when both are
+# configured.
+_iwiki_remote_selected() {
+    [[ -n "${IWIKI_REMOTE_URL:-}" ]]                 || return 1
+    [[ -n "${IWIKI_REMOTE_TOKEN:-}" ]]               || return 1
+    [[ -f "$(iwiki_mcp_remote_config_file)" ]]       || return 1
+    return 0
+}
+
 # Resolve the iwiki-mcp executable to an absolute path and export IWIKI_COMMAND.
 # An explicit override is honored only when IWIKI_COMMAND is a NON-EMPTY value;
 # an unset OR empty IWIKI_COMMAND is treated as absent and resolved from PATH via
@@ -33,12 +53,15 @@ iwiki_resolve_command() {
     export IWIKI_COMMAND
 }
 
-# Return 0 (enabled) only when the iwiki MCP server should be registered:
+# Return 0 (enabled) when the iwiki MCP server should be registered, in either
+# of two modes. Remote mode needs only a URL, a token, and the tracked remote
+# config. Local (stdio) mode needs:
 #   - the binary resolved (IWIKI_COMMAND non-empty), AND
 #   - iwiki is configured (IWIKI_LLM_KEY non-empty), AND
 #   - the tracked config file exists.
 # Returns 1 otherwise, so launch proceeds without the server (no hard failure).
 iwiki_mcp_enabled() {
+    _iwiki_remote_selected && return 0
     iwiki_resolve_command
     [[ -n "${IWIKI_COMMAND:-}" ]]            || return 1
     [[ -n "${IWIKI_LLM_KEY:-}" ]]            || return 1
@@ -69,7 +92,10 @@ _iwiki_code_graph_env_lines() {
 }
 
 # Print the config path to hand to `--mcp-config`.
-# Without configured code-graph vars this is the tracked file itself. With them,
+# In remote mode this is the tracked remote config; the code-graph render does
+# not apply, because a hosted server owns its own storage and code-graph cache.
+# In local mode, without configured code-graph vars this is the tracked file
+# itself. With them,
 # a sibling *.runtime.json is rendered by splicing the extra keys into the `env`
 # object; it holds only `${VAR}` placeholders, so it stays secret-free like the
 # tracked original (it is git-ignored because it is machine-specific). Any write
@@ -77,6 +103,10 @@ _iwiki_code_graph_env_lines() {
 # without the code-graph overrides.
 iwiki_mcp_launch_config() {
     local tracked lines runtime
+    if _iwiki_remote_selected; then
+        iwiki_mcp_remote_config_file
+        return 0
+    fi
     tracked="$(iwiki_mcp_config_file)"
     lines="$(_iwiki_code_graph_env_lines)"
     if [[ -z "$lines" ]]; then

--- a/lib/iwiki/mcp.sh
+++ b/lib/iwiki/mcp.sh
@@ -2,12 +2,14 @@
 
 #######################################
 # iwiki MCP Registration Helper
-# Description: Resolves the iwiki-mcp binary to an absolute path and decides
-#              whether the tracked, secret-free mcp/iwiki.json should be handed
-#              to Claude Code via --mcp-config. The IWIKI_* values are already
+# Description: Decides whether an iwiki MCP server is handed to Claude Code via
+#              --mcp-config, and which tracked, secret-free config describes it:
+#              mcp/iwiki-remote.json for a hosted Streamable HTTP server, or
+#              mcp/iwiki.json for the local stdio server (optionally rendered
+#              with the code-graph overrides). The IWIKI_* values are already
 #              exported by lib/config/env-map.sh (de-prefixed from
 #              ICLAUDE_IWIKI_* in .claude_config); this module only resolves the
-#              binary path and evaluates the enable gate.
+#              binary path, evaluates the enable gate, and picks the config.
 #######################################
 
 # Absolute path to the tracked, secret-free MCP config file.
@@ -95,12 +97,13 @@ _iwiki_code_graph_env_lines() {
 # In remote mode this is the tracked remote config; the code-graph render does
 # not apply, because a hosted server owns its own storage and code-graph cache.
 # In local mode, without configured code-graph vars this is the tracked file
-# itself. With them,
-# a sibling *.runtime.json is rendered by splicing the extra keys into the `env`
-# object; it holds only `${VAR}` placeholders, so it stays secret-free like the
-# tracked original (it is git-ignored because it is machine-specific). Any write
-# or render failure falls back to the tracked file — iwiki still starts, only
-# without the code-graph overrides.
+# itself, and any render left over from an earlier launch is removed so a stale
+# file can never be mistaken for the active config. With them, a sibling
+# *.runtime.json is rendered by splicing the extra keys into the `env` object; it
+# holds only `${VAR}` placeholders, so it stays secret-free like the tracked
+# original (it is git-ignored because it is machine-specific). A write failure,
+# or a tracked file with no `env` object to splice into, falls back to the
+# tracked file — iwiki still starts, only without the code-graph overrides.
 iwiki_mcp_launch_config() {
     local tracked lines runtime
     if _iwiki_remote_selected; then
@@ -108,15 +111,17 @@ iwiki_mcp_launch_config() {
         return 0
     fi
     tracked="$(iwiki_mcp_config_file)"
+    runtime="${tracked%.json}.runtime.json"
     lines="$(_iwiki_code_graph_env_lines)"
     if [[ -z "$lines" ]]; then
+        rm -f "$runtime" 2>/dev/null || true
         printf '%s' "$tracked"
         return 0
     fi
-    runtime="${tracked%.json}.runtime.json"
     if awk -v ins="$lines" '
         { print }
         /"env"[[:space:]]*:[[:space:]]*\{/ && !spliced { printf "%s", ins; spliced = 1 }
+        END { if (!spliced) exit 3 }
     ' "$tracked" > "$runtime" 2>/dev/null; then
         printf '%s' "$runtime"
     else

--- a/lib/launcher/launch.sh
+++ b/lib/launcher/launch.sh
@@ -828,8 +828,10 @@ launch_claude() {
     # Claude Code can expand ${IWIKI_COMMAND}/${IWIKI_*} at spawn time. The flag
     # is added to claude_cmd_arr, so it flows into every launch branch below.
     # (The microVM path execs earlier and is intentionally not covered.)
+    # iwiki_mcp_launch_config returns the tracked file, or a rendered sibling when
+    # the optional IWIKI_CODE_GRAPH_* vars are configured (see lib/iwiki/mcp.sh).
     if declare -f iwiki_mcp_enabled >/dev/null 2>&1 && iwiki_mcp_enabled; then
-        claude_cmd_arr+=( --mcp-config "$(iwiki_mcp_config_file)" )
+        claude_cmd_arr+=( --mcp-config "$(iwiki_mcp_launch_config)" )
     fi
 
     # Launch Claude Code

--- a/tests/test_iwiki_mcp.sh
+++ b/tests/test_iwiki_mcp.sh
@@ -43,6 +43,34 @@ assert_eq "$(PATH="/nonexistent"; CLAUDE_CONFIG_DIR="$TD/.claude-isolated"; IWIK
 assert_eq "$(PATH="$TD/bin:$PATH"; CLAUDE_CONFIG_DIR="$TD/nowhere"; IWIKI_LLM_KEY=sk-x; unset IWIKI_COMMAND; iwiki_mcp_enabled && echo YES || echo NO)" \
   "NO" "disabled without config file"
 
+# ---------------------------------------------------------------------------
+# iwiki_mcp_launch_config: code-graph vars are forwarded only when configured.
+# ---------------------------------------------------------------------------
+CFG="$TD/.claude-isolated/mcp/iwiki.json"
+printf '%s\n' '{' '  "mcpServers": {' '    "iwiki": {' '      "env": {' \
+  '        "IWIKI_TOP_K": "${IWIKI_TOP_K:-8}"' '      }' '    }' '  }' '}' > "$CFG"
+
+# No code-graph var set: the tracked file is used verbatim, nothing is rendered.
+assert_eq "$(CLAUDE_CONFIG_DIR="$TD/.claude-isolated"; unset "${_IWIKI_CODE_GRAPH_VARS[@]}"; iwiki_mcp_launch_config)" \
+  "$CFG" "launch config: tracked file without code-graph vars"
+assert_eq "$([[ -e "${CFG%.json}.runtime.json" ]] && echo YES || echo NO)" \
+  "NO" "launch config: no runtime file rendered"
+
+# An empty value is treated as unset: the server rejects an empty code-graph
+# value, so it must never reach the rendered config.
+assert_eq "$(CLAUDE_CONFIG_DIR="$TD/.claude-isolated"; IWIKI_CODE_GRAPH_ENABLED=""; iwiki_mcp_launch_config)" \
+  "$CFG" "launch config: empty var does not trigger a render"
+
+# A configured var: a runtime file is rendered with the placeholder spliced in.
+RENDERED="$(CLAUDE_CONFIG_DIR="$TD/.claude-isolated"; IWIKI_CODE_GRAPH_ENABLED=false; IWIKI_CODE_GRAPH_MAX_FILES=100; iwiki_mcp_launch_config)"
+assert_eq "$RENDERED" "${CFG%.json}.runtime.json" "launch config: renders a runtime file"
+assert_eq "$(python3 -m json.tool "$RENDERED" >/dev/null 2>&1 && echo OK || echo BAD)" \
+  "OK" "launch config: rendered file is valid JSON"
+assert_eq "$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["mcpServers"]["iwiki"]["env"]["IWIKI_CODE_GRAPH_ENABLED"])' "$RENDERED")" \
+  '${IWIKI_CODE_GRAPH_ENABLED}' "launch config: placeholder, not the literal value"
+assert_eq "$(python3 -c 'import json,sys; e=json.load(open(sys.argv[1]))["mcpServers"]["iwiki"]["env"]; print(",".join(sorted(e)))' "$RENDERED")" \
+  "IWIKI_CODE_GRAPH_ENABLED,IWIKI_CODE_GRAPH_MAX_FILES,IWIKI_TOP_K" "launch config: only configured vars are added"
+
 rm -rf "$TD"
 echo "iwiki-mcp: PASS=$PASS FAIL=$FAIL"
 [[ "$FAIL" == "0" ]]

--- a/tests/test_iwiki_mcp.sh
+++ b/tests/test_iwiki_mcp.sh
@@ -71,6 +71,34 @@ assert_eq "$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["mc
 assert_eq "$(python3 -c 'import json,sys; e=json.load(open(sys.argv[1]))["mcpServers"]["iwiki"]["env"]; print(",".join(sorted(e)))' "$RENDERED")" \
   "IWIKI_CODE_GRAPH_ENABLED,IWIKI_CODE_GRAPH_MAX_FILES,IWIKI_TOP_K" "launch config: only configured vars are added"
 
+# ---------------------------------------------------------------------------
+# Remote (hosted Streamable HTTP) mode: URL + token, no local binary needed.
+# ---------------------------------------------------------------------------
+RCFG="$TD/.claude-isolated/mcp/iwiki-remote.json"
+printf '%s' '{"mcpServers":{"iwiki":{"type":"http","url":"${IWIKI_REMOTE_URL}"}}}' > "$RCFG"
+
+# Enabled with neither an iwiki-mcp binary nor an embeddings key: a hosted
+# server keeps both server-side.
+assert_eq "$(PATH="/nonexistent"; CLAUDE_CONFIG_DIR="$TD/.claude-isolated"; unset IWIKI_LLM_KEY IWIKI_COMMAND; IWIKI_REMOTE_URL=https://w.example/mcp; IWIKI_REMOTE_TOKEN=t; iwiki_mcp_enabled && echo YES || echo NO)" \
+  "YES" "remote: enabled without binary or LLM key"
+
+# A URL without a token is not usable, so remote stays off.
+assert_eq "$(PATH="/nonexistent"; CLAUDE_CONFIG_DIR="$TD/.claude-isolated"; unset IWIKI_LLM_KEY IWIKI_COMMAND IWIKI_REMOTE_TOKEN; IWIKI_REMOTE_URL=https://w.example/mcp; iwiki_mcp_enabled && echo YES || echo NO)" \
+  "NO" "remote: disabled without a token"
+
+# Remote is the deliberate opt-in, so it wins over a usable local install.
+assert_eq "$(PATH="$TD/bin:$PATH"; CLAUDE_CONFIG_DIR="$TD/.claude-isolated"; IWIKI_LLM_KEY=sk-x; unset IWIKI_COMMAND; IWIKI_REMOTE_URL=https://w.example/mcp; IWIKI_REMOTE_TOKEN=t; iwiki_mcp_launch_config)" \
+  "$RCFG" "remote: selected over the local config"
+
+# Remote never renders the code-graph sibling: a hosted server owns that cache.
+assert_eq "$(CLAUDE_CONFIG_DIR="$TD/.claude-isolated"; IWIKI_REMOTE_URL=https://w.example/mcp; IWIKI_REMOTE_TOKEN=t; IWIKI_CODE_GRAPH_ENABLED=true; iwiki_mcp_launch_config)" \
+  "$RCFG" "remote: no code-graph render"
+
+# Without the tracked remote config, remote cannot be selected.
+rm -f "$RCFG"
+assert_eq "$(CLAUDE_CONFIG_DIR="$TD/.claude-isolated"; unset "${_IWIKI_CODE_GRAPH_VARS[@]}"; IWIKI_REMOTE_URL=https://w.example/mcp; IWIKI_REMOTE_TOKEN=t; iwiki_mcp_launch_config)" \
+  "$CFG" "remote: falls back to local without the remote config"
+
 rm -rf "$TD"
 echo "iwiki-mcp: PASS=$PASS FAIL=$FAIL"
 [[ "$FAIL" == "0" ]]

--- a/tests/test_iwiki_mcp.sh
+++ b/tests/test_iwiki_mcp.sh
@@ -71,6 +71,22 @@ assert_eq "$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["mc
 assert_eq "$(python3 -c 'import json,sys; e=json.load(open(sys.argv[1]))["mcpServers"]["iwiki"]["env"]; print(",".join(sorted(e)))' "$RENDERED")" \
   "IWIKI_CODE_GRAPH_ENABLED,IWIKI_CODE_GRAPH_MAX_FILES,IWIKI_TOP_K" "launch config: only configured vars are added"
 
+# A tracked file with no `env` object cannot be spliced: fall back to it and
+# leave no half-rendered sibling behind.
+printf '%s' '{"mcpServers":{"iwiki":{"type":"stdio"}}}' > "$TD/.claude-isolated/mcp/noenv.json"
+assert_eq "$(CLAUDE_CONFIG_DIR="$TD/.claude-isolated"; iwiki_mcp_config_file(){ printf '%s' "$TD/.claude-isolated/mcp/noenv.json"; }; IWIKI_CODE_GRAPH_ENABLED=true; iwiki_mcp_launch_config)" \
+  "$TD/.claude-isolated/mcp/noenv.json" "launch config: falls back when there is no env object"
+assert_eq "$([[ -e "$TD/.claude-isolated/mcp/noenv.runtime.json" ]] && echo YES || echo NO)" \
+  "NO" "launch config: no leftover render after a failed splice"
+
+# A render from an earlier launch is removed once the vars are gone, so a stale
+# file is never mistaken for the active config.
+touch "${CFG%.json}.runtime.json"
+assert_eq "$(CLAUDE_CONFIG_DIR="$TD/.claude-isolated"; unset "${_IWIKI_CODE_GRAPH_VARS[@]}"; iwiki_mcp_launch_config)" \
+  "$CFG" "launch config: tracked file after the vars are unset"
+assert_eq "$([[ -e "${CFG%.json}.runtime.json" ]] && echo YES || echo NO)" \
+  "NO" "launch config: stale render removed"
+
 # ---------------------------------------------------------------------------
 # Remote (hosted Streamable HTTP) mode: URL + token, no local binary needed.
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

iclaude's iwiki MCP registration had drifted from the current `iwiki-mcp` server: 11 of the 26 `IWIKI_*` variables were forwarded, hosted servers could not be reached at all, and the project `.iwiki.toml` documented none of its optional tables.

- Forward the full stdio surface: search mode, reranker, chat model, idle timeout, the seed/BFS retrieval tuning, and the PostgreSQL password.
- Forward `IWIKI_CODE_GRAPH_*` only when configured, through a launch-time render.
- Register a hosted `iwiki-mcp serve --transport streamable-http` server via URL and bearer token.
- Fill `.iwiki.toml` with commented `[code_graph]` and `[storage]` examples.

## Why the code-graph variables need a render

`codegraph/config.py` applies the environment **after** the project's `.iwiki.toml` `[code_graph]` table, and rejects an empty value for each of the four variables. Probing a stub stdio server under the isolated Claude Code binary showed that an unresolved `${VAR:-}` arrives as a **set-but-empty** entry (`FOO=`), not an omitted key — so a static placeholder would either break the code tools or silently override every project.

`iwiki_mcp_launch_config` therefore returns the tracked path unchanged when no code-graph variable is set, and otherwise splices one placeholder line per configured variable into a git-ignored `mcp/iwiki.runtime.json`. The render holds placeholders only, so it stays secret-free; a write failure, or a tracked file with no `env` object, falls back to the tracked file.

## Remote mode

A second tracked config, `mcp/iwiki-remote.json`, uses `type: "http"` with `${IWIKI_REMOTE_URL}` and an `Authorization: Bearer ${IWIKI_REMOTE_TOKEN}` header; a probe against a stub HTTP server confirmed Claude Code expands placeholders in `url` and `headers` exactly as in `env`. Remote mode requires neither the `iwiki-mcp` binary nor an embeddings key, because a hosted server owns its storage, credentials, and code-graph cache. Setting the URL is the opt-in and wins over a local install.

`IWIKI_IDLE_TIMEOUT_SECONDS` is pinned to `86400` — the value `engine/config.py` actually defaults to, while the upstream README documents `1800`.

## Testing

- `tests/test_iwiki_mcp.sh` — PASS=23 FAIL=0, covering the unset / empty / configured render branches, placeholder fidelity, splice failure, stale-render cleanup, and the four remote-selection cases.
- `tests/test_env_map.sh` PASS=10, `tests/test_config_migration.sh` PASS=10.
- Rendered the real config: valid JSON and confirmed git-ignored. `.iwiki.toml` and `mcp/iwiki-remote.json` parse.

Not verified live: no hosted iwiki server was available, so only URL and token delivery were proven, not a full MCP handshake against one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)