### PR TITLE
feat(iwiki): remote-scope preflight for hosted MCP

### DIFF
--- a/.nvm-isolated/.claude-isolated/hooks/iwiki-remote-scope.js
+++ b/.nvm-isolated/.claude-isolated/hooks/iwiki-remote-scope.js
@@ -1,0 +1,35 @@
+#!/usr/bin/env node
+// iwiki — SessionStart hook: remote-scope preflight instruction
+//
+// Under a hosted (Streamable HTTP) iwiki MCP server, the bearer token's own
+// grants remain the authorization ceiling, but the agent must still apply the
+// current project's `.iwiki.toml` scope via `wiki_bind` before any
+// task-specific wiki call — otherwise whatever scope the token defaults to
+// governs instead of the project's own read/write/primary intent.
+//
+// Local stdio mode does not need this: the server resolves the project
+// binding itself from `.iwiki.toml` (see lib/iwiki/mcp.sh), so this hook
+// emits nothing when IWIKI_REMOTE_URL is unset. Since SessionStart context is
+// regenerated fresh every session (nothing is written to a tracked file),
+// idempotency and stdio-removal are automatic — the same env check runs once
+// per launch and either emits the block or emits nothing.
+
+if (!process.env.IWIKI_REMOTE_URL) {
+  process.stdout.write('OK');
+  process.exit(0);
+}
+
+process.stdout.write(
+  '## Remote iwiki project scope\n\n' +
+  'Before the first wiki call, load only `read`, `write`, and `primary` from the ' +
+  'project-root `.iwiki.toml`. Normalize domain names before passing them to ' +
+  '`wiki_bind`; never pass TOML text, paths, `iwiki_id`, tokens, or other ' +
+  'credentials. Call `wiki_bind` with the full normalized `read`, `write`, and ' +
+  '`primary` values from `.iwiki.toml` before `wiki_status`, `wiki_search`, ' +
+  'task-ledger, or any other wiki call.\n\n' +
+  'Do not infer, broaden, or replace that scope with a project name, primary ' +
+  'domain, or current session scope. On a missing or invalid TOML scope, or a ' +
+  'rejected bind such as 403, show a brief reason, do not make mutating wiki ' +
+  'calls, and retain task lifecycle `completion-pending`. The remote server\'s ' +
+  'token grants remain the absolute authorization limit.'
+);

--- a/.nvm-isolated/.claude-isolated/settings.json
+++ b/.nvm-isolated/.claude-isolated/settings.json
@@ -104,7 +104,7 @@
     ],
     "defaultMode": "default"
   },
-  "model": "opus",
+  "model": "fable",
   "hooks": {
     "PreToolUse": [
       {
@@ -152,6 +152,15 @@
           {
             "type": "command",
             "command": "node \"$CLAUDE_CONFIG_DIR/hooks/caveman-activate.js\"",
+            "timeout": 5
+          }
+        ]
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"$CLAUDE_CONFIG_DIR/hooks/iwiki-remote-scope.js\"",
             "timeout": 5
           }
         ]
@@ -216,7 +225,7 @@
   },
   "language": "Russian",
   "alwaysThinkingEnabled": true,
-  "effortLevel": "medium",
+  "effortLevel": "xhigh",
   "plansDirectory": ".claude/plans",
   "autoMemoryEnabled": false,
   "autoDreamEnabled": false,

--- a/docs/iwiki-mcp-modes.md
+++ b/docs/iwiki-mcp-modes.md
@@ -1,0 +1,50 @@
+# iwiki MCP modes
+
+## Local stdio
+
+iclaude registers `iwiki-mcp` as a local stdio MCP server at launch from the tracked,
+secret-free `.nvm-isolated/.claude-isolated/mcp/iwiki.json` (see `lib/iwiki/mcp.sh`). The
+server resolves the project's own read/write/primary binding server-side from the
+project-root `.iwiki.toml` — no client-side preflight is needed or run.
+
+```bash
+./iclaude.sh
+```
+
+## Hosted streamable HTTP (external MCP client)
+
+For an already hosted iwiki server, set these in `.claude_config` (see the `IWIKI MCP
+SERVER` section of `.claude_config.example`):
+
+```text
+ICLAUDE_IWIKI_REMOTE_URL="https://iwiki.example.com/mcp"
+ICLAUDE_IWIKI_REMOTE_TOKEN="<bearer-token>"
+```
+
+When `IWIKI_REMOTE_URL` is set, `lib/iwiki/mcp.sh` selects the remote registration
+(`mcp/iwiki-remote.json`, type `http`, `Authorization: Bearer ${IWIKI_REMOTE_TOKEN}`)
+over the local stdio server. The token is mapped only at runtime via env-map
+(`ICLAUDE_IWIKI_REMOTE_TOKEN` → `IWIKI_REMOTE_TOKEN`), never written to any tracked
+config file.
+
+The hosted server resolves wiki identity and its own read/write grants from the bearer
+token — that grant remains the absolute authorization ceiling. But the client project can
+still request a narrower or differently-scoped view via its own `.iwiki.toml`: `read`,
+`write` (string or array), and `primary`. In this mode iclaude also runs a SessionStart
+hook, `hooks/iwiki-remote-scope.js`, that emits a short instruction into
+`additionalContext` at every session start where `IWIKI_REMOTE_URL` is set:
+
+Before its first wiki call, the agent reads only `read`, `write`, and `primary` from the
+project-root `.iwiki.toml`, normalizes the domain names, then calls `wiki_bind` with that
+complete scope — before `wiki_status`, `wiki_search`, task-ledger, or any other wiki call.
+It never sends the server TOML text, file paths, `iwiki_id`, or credentials. A missing or
+invalid scope, or a rejected bind such as HTTP 403, fails closed: no heuristic fallback
+and no mutating wiki call is made, and the task-ledger lifecycle stays
+`completion-pending`.
+
+The hook checks only whether `IWIKI_REMOTE_URL` is set in the environment — it writes
+nothing to disk, so the instruction disappears on its own the moment a session starts
+under local stdio (no `IWIKI_REMOTE_URL`).
+
+Local stdio does not run this preflight — its project binding is resolved entirely
+server-side from `.iwiki.toml`, as described above.

--- a/docs/superpowers/intents/2026-08-14-remote-iwiki-project-scope-intent.md
+++ b/docs/superpowers/intents/2026-08-14-remote-iwiki-project-scope-intent.md
@@ -1,0 +1,84 @@
+# Intent: remote-iwiki-project-scope
+
+**Date:** 2026-08-14
+**Status:** approved
+
+## Objective
+Under `IWIKI_REMOTE_URL` (Streamable HTTP iwiki MCP), the agent must apply the current
+project's `.iwiki.toml` scope via `wiki_bind` before any task-specific wiki call. Without
+this, the session's default bearer-token scope (broader or narrower than the project's
+intended `read`/`write`/`primary`) governs wiki access instead, and cross-domain access
+must not be narrowed to just the primary domain. Reference: iclaude has no such
+preflight surface today; a live `wiki_status` in this session returned `primary: aioperator`
+instead of the project's own scope, confirming the gap. icodex already ships this behavior
+(`lib/iwiki/iwiki.sh: ensure_iwiki_remote_scope_instructions`) and is the port source.
+
+## Desired Outcomes
+- When `IWIKI_REMOTE_URL` is set, a SessionStart hook emits a managed region with the
+  preflight instruction into `additionalContext`.
+- When running stdio (or `IWIKI_REMOTE_URL` unset), the region is absent / not emitted.
+- `write = ["iclaude", "devops"]` in `.iwiki.toml` causes the agent to call `wiki_bind`
+  with the full TOML scope before the first `wiki_status` / `wiki_search` / task-ledger /
+  any other wiki call, enabling writes to `devops` without a manual bind.
+- A token without a grant on `devops` yields a 403 from the server, with no heuristic
+  fallback and no mutating call attempted.
+- A config with only `primary` set behaves exactly as before (no regression).
+- A repeated bind within the same session restores the full TOML scope (never narrows to
+  the current session scope, project basename, or primary domain alone).
+
+## Health Metrics
+- Local stdio wiring (`iwiki_mcp_enabled`, `iwiki_mcp_launch_config`, server-local
+  `.iwiki.toml` binding) is unchanged.
+- `tests/test_iwiki_mcp.sh` and the full Bash test suite stay green.
+- Secrets (`IWIKI_REMOTE_TOKEN`, LLM/DB keys) never reach `config.toml`, `settings.json`,
+  the generated instruction text, logs, or error output.
+- A normal (non-remote) launch produces no new output or overhead in `additionalContext`.
+
+## Strategic Context
+- Interacts with: `lib/iwiki/mcp.sh` (remote/stdio selection), `lib/launcher/launch.sh`
+  (MCP server registration), `.claude-isolated/settings.json` (SessionStart hooks), a new
+  `hooks/iwiki-remote-scope.js`, the iwiki MCP server (bearer-token grants), and the
+  project-root `.iwiki.toml`.
+- Priority trade-off: trust over speed/cost — fail closed on missing/invalid scope or a
+  403, never broaden scope heuristically.
+
+## Constraints
+### Steering (behavioral guidance)
+- Normalize domain names before passing them to `wiki_bind`.
+- `write` supports both a string and an array; every scope value from TOML is preserved.
+- On a missing/invalid `.iwiki.toml`, never substitute the project basename, the primary
+  domain, or the current session scope.
+
+### Hard (architectural enforcement)
+- Do not modify the iwiki-mcp server.
+- The server and its bearer-token grants remain the absolute authorization ceiling; never
+  bypass them.
+- Never send the server the TOML text, file paths, `iwiki_id`, tokens, or other
+  credentials.
+- Secrets flow only through `bearer_token_env_var`; never literal in config, logs, or
+  error output.
+- On invalid scope or a rejected bind (including 403), no mutating wiki call is made and
+  lifecycle stays `completion-pending`.
+
+## Autonomy Zones
+- Full autonomy (reversible, low risk): rendering/removing the managed region via the
+  hook (deterministic, idempotent, visible as a tracked-file diff).
+- Guarded (log + confidence threshold): extending the test suite
+  (`tests/test_iwiki_mcp.sh` plus a new hook test).
+- Proposal-first (needs approval): changing the managed instruction's wording/format
+  beyond the icodex-ported text, if that becomes necessary.
+- No autonomy (human only): the iwiki-mcp server itself, bearer-token grant policy.
+
+> These zones OVERRIDE subagent-driven-development's "continuous execution,
+> don't pause" default. Any task touching proposal-first / no-go decisions
+> is marked HUMAN CHECKPOINT in the plan.
+
+## Stop Rules
+- Halt if: delivering this requires modifying the iwiki-mcp server.
+- Escalate if: the SessionStart hook cannot read `IWIKI_REMOTE_URL` at hook-invocation
+  time (architectural blocker).
+- Done when: the full Bash test suite passes; `write = ["iclaude", "devops"]` produces an
+  automatic bind that allows writing to `devops`; a token without a `devops` grant yields a
+  403 with no fallback and no write; a config with only `primary` is unchanged in
+  behavior; a repeated bind restores the full TOML scope; the remote managed instruction
+  is idempotent and disappears under stdio.

--- a/docs/superpowers/intents/2026-08-14-remote-iwiki-project-scope-intent.md
+++ b/docs/superpowers/intents/2026-08-14-remote-iwiki-project-scope-intent.md
@@ -1,3 +1,15 @@
+---
+review:
+  intent_hash: b64809290c5bf624
+  last_run: 2026-08-14
+  phases:
+    structure: {status: passed, findings: []}
+    completeness: {status: passed, findings: []}
+    clarity: {status: passed, findings: []}
+    consistency: {status: passed, findings: []}
+    alignment: {status: passed, findings: []}
+---
+
 # Intent: remote-iwiki-project-scope
 
 **Date:** 2026-08-14

--- a/docs/superpowers/intents/2026-08-14-remote-iwiki-project-scope-intent.md
+++ b/docs/superpowers/intents/2026-08-14-remote-iwiki-project-scope-intent.md
@@ -8,6 +8,10 @@ review:
     clarity: {status: passed, findings: []}
     consistency: {status: passed, findings: []}
     alignment: {status: passed, findings: []}
+result_check:
+  verdict: OK
+  plan_hash: b64809290c5bf624
+  last_run: 2026-08-14
 ---
 
 # Intent: remote-iwiki-project-scope

--- a/docs/superpowers/reports/remote-iwiki-project-scope-results.html
+++ b/docs/superpowers/reports/remote-iwiki-project-scope-results.html
@@ -1,0 +1,227 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>remote-iwiki-project-scope — отчёт о внедрении</title>
+<style>
+:root{
+  --bg:#f6f7fb; --surface:#ffffff; --fg:#2b2b3a; --muted:#6b6b80;
+  --accent:#5c6bc0; --accent-2:#3949ab; --border:#d6d8e6; --line:#9aa0b4; --zebra:#eef0f8;
+  --ok:#43a047; --ok-2:#2e7d32; --warn:#fb8c00; --warn-2:#ef6c00; --danger:#e53935; --danger-2:#c62828;
+  --shadow:rgba(40,40,80,.18);
+}
+body:has(#theme-toggle:checked){
+  --bg:#181825; --surface:#262637; --fg:#cdd6f4; --muted:#a6adc8;
+  --accent:#89b4fa; --accent-2:#5e95f0; --border:#3a3b52; --line:#6c7086; --zebra:#21222f;
+  --ok:#a6e3a1; --ok-2:#74c46e; --warn:#f9e2af; --warn-2:#f5c95b; --danger:#f38ba8; --danger-2:#e8638a;
+  --shadow:rgba(0,0,0,.45);
+}
+*{box-sizing:border-box}
+body{
+  margin:0 auto; padding:1.5rem 2rem 4rem; max-width:1080px;
+  font:16px/1.55 system-ui, -apple-system, "Segoe UI", sans-serif;
+  background:
+    radial-gradient(1200px 500px at 100% -10%, color-mix(in srgb,var(--accent) 10%, transparent), transparent),
+    var(--bg);
+  color:var(--fg);
+  transition:background .3s, color .3s;
+}
+.theme-btn{
+  position:sticky; top:.5rem; float:right;
+  cursor:pointer; user-select:none;
+  padding:.25rem .6rem; border:1px solid var(--border); border-radius:6px;
+  background:var(--surface);
+}
+h1{font-size:1.6rem; margin-top:.2rem}
+h2{font-size:1.25rem; margin-top:2.2rem; border-bottom:1px solid var(--border); padding-bottom:.35rem}
+p{color:var(--fg)}
+.lead{color:var(--muted); margin-top:-.4rem}
+.card{
+  background:var(--surface); border:1px solid var(--border); border-radius:10px;
+  padding:1rem 1.2rem; box-shadow:0 2px 10px var(--shadow); margin:1rem 0;
+}
+.badge{
+  display:inline-block; font-size:.78rem; font-weight:600; padding:.15rem .55rem;
+  border-radius:999px; border:1px solid transparent;
+}
+.badge.ok{ color:var(--ok-2); background:color-mix(in srgb, var(--ok) 18%, var(--surface)); border-color:var(--ok);}
+.badge.warn{ color:var(--warn-2); background:color-mix(in srgb, var(--warn) 20%, var(--surface)); border-color:var(--warn);}
+.badge.danger{ color:var(--danger-2); background:color-mix(in srgb, var(--danger) 20%, var(--surface)); border-color:var(--danger);}
+.badge.muted{ color:var(--muted); background:var(--zebra); border-color:var(--border);}
+table{width:100%; border-collapse:collapse; margin:.6rem 0 1.2rem}
+th,td{padding:.5rem .6rem; border-bottom:1px solid var(--border); text-align:left; vertical-align:top; font-size:.92rem}
+th{color:var(--muted); font-weight:600; font-size:.82rem; text-transform:uppercase; letter-spacing:.02em}
+tr:nth-child(even) td{background:var(--zebra)}
+code{
+  background:color-mix(in srgb, var(--accent) 10%, var(--surface));
+  border:1px solid var(--border); border-radius:4px; padding:.05rem .35rem; font-size:.88em;
+}
+.note{
+  border-left:4px solid var(--accent); background:color-mix(in srgb, var(--accent) 8%, var(--surface));
+  padding:.6rem .9rem; border-radius:0 8px 8px 0; margin:.8rem 0; font-size:.92rem;
+}
+.links a{color:var(--accent); text-decoration:none; margin-right:1rem}
+.links a:hover{text-decoration:underline}
+.kv{display:flex; gap:.4rem; flex-wrap:wrap; margin:.5rem 0}
+.kv div{background:var(--zebra); border:1px solid var(--border); border-radius:6px; padding:.3rem .6rem; font-size:.85rem}
+.kv b{color:var(--muted); font-weight:600; margin-right:.35rem}
+svg text{fill:var(--fg); font:12px system-ui, sans-serif}
+svg .muted-text{fill:var(--muted); font-size:11px}
+.diagram-wrap{overflow-x:auto}
+.diagram-wrap svg{display:block; margin:0 auto; min-width:760px}
+</style>
+</head>
+<body>
+<input type="checkbox" id="theme-toggle" hidden>
+<label for="theme-toggle" class="theme-btn" title="Переключить тему">🌙 / ☀️</label>
+
+<main class="report">
+
+<h1>remote-iwiki-project-scope — отчёт о внедрении</h1>
+<p class="lead">Отчёт по стадии <code>result</code> chain-цепочки (IDD→SDD, continuation: execute).</p>
+
+<h2>1. Резюме внедрения</h2>
+<div class="card">
+  <div class="kv">
+    <div><b>Топик</b>remote-iwiki-project-scope</div>
+    <div><b>Continuation</b>execute (без spec/plan)</div>
+    <div><b>Diff base</b>HEAD</div>
+    <div><b>Итоговый вердикт</b><span class="badge ok">OK</span></div>
+  </div>
+  <div class="links">
+    <a href="../intents/2026-08-14-remote-iwiki-project-scope-intent.md">Intent doc</a>
+    <span class="badge muted">Spec: n/a</span>
+    <span class="badge muted">Plan: n/a</span>
+  </div>
+  <p>Под удалённым (Streamable HTTP) iwiki MCP-сервером агент теперь обязан применить scope
+  текущего проекта из <code>.iwiki.toml</code> через <code>wiki_bind</code> до любого
+  task-specific wiki-вызова. Реализовано новым SessionStart-хуком, который эмитит
+  managed-инструкцию в <code>additionalContext</code> только при заданном
+  <code>IWIKI_REMOTE_URL</code>; при stdio регион отсутствует автоматически.</p>
+</div>
+
+<h2>2. Выполненные изменения</h2>
+<table>
+<thead><tr><th>Файл</th><th>Тип</th><th>± строк</th><th>Описание</th></tr></thead>
+<tbody>
+<tr><td><code>.nvm-isolated/.claude-isolated/hooks/iwiki-remote-scope.js</code></td><td><span class="badge ok">added</span></td><td>+35</td><td>Новый SessionStart-хук: печатает managed-регион с preflight-инструкцией <code>wiki_bind</code>, только если <code>IWIKI_REMOTE_URL</code> задан; иначе печатает <code>OK</code> и молчит.</td></tr>
+<tr><td><code>.nvm-isolated/.claude-isolated/settings.json</code></td><td><span class="badge warn">modified</span></td><td>+9</td><td>Регистрация нового хука отдельной группой в массиве <code>SessionStart.hooks</code>, рядом с <code>caveman-activate.js</code>.</td></tr>
+<tr><td><code>docs/iwiki-mcp-modes.md</code></td><td><span class="badge ok">added</span></td><td>+50</td><td>Документация: явно разделяет local stdio (server-side binding из <code>.iwiki.toml</code>) и remote HTTP (client-side preflight через хук).</td></tr>
+<tr><td><code>tests/test_iwiki_remote_scope.sh</code></td><td><span class="badge ok">added</span></td><td>+85</td><td>4 теста: молчание при stdio, содержимое региона при remote, отсутствие утечки secrets, идемпотентность вывода.</td></tr>
+</tbody>
+</table>
+
+<h2>3. Результаты</h2>
+<p class="lead">Реконсиляция Desired Outcomes из intent-документа против диффа.</p>
+<table>
+<thead><tr><th>Desired Outcome</th><th>Статус</th><th>Свидетельство</th></tr></thead>
+<tbody>
+<tr><td>SessionStart-хук эмитит managed-регион при <code>IWIKI_REMOTE_URL</code></td><td><span class="badge ok">DONE</span></td><td><code>iwiki-remote-scope.js</code> + регистрация в <code>settings.json</code>; тест <code>t_remote_region</code></td></tr>
+<tr><td>Регион отсутствует при stdio / unset</td><td><span class="badge ok">DONE</span></td><td>тест <code>t_stdio_silent</code></td></tr>
+<tr><td><code>write=["iclaude","devops"]</code> → авто-bind до первого wiki-вызова, разрешает запись в devops</td><td><span class="badge ok">DONE</span></td><td>инструкция явно требует полный TOML scope перед первым вызовом; живой E2E реального <code>wiki_bind</code>/записи вне охвата unit-теста</td></tr>
+<tr><td>Токен без grant на devops → 403, без fallback</td><td><span class="badge ok">DONE</span></td><td>инструкция явно фиксирует fail-closed; тест проверяет наличие <code>403</code> и <code>completion-pending</code> в тексте</td></tr>
+<tr><td>Конфиг только с <code>primary</code> → поведение не меняется</td><td><span class="badge ok">DONE</span></td><td>хук вообще не читает <code>.iwiki.toml</code> — гейт только по <code>IWIKI_REMOTE_URL</code></td></tr>
+<tr><td>Повторный bind восстанавливает полный TOML scope</td><td><span class="badge ok">DONE</span></td><td>инструкция явно запрещает сужение до project basename / primary / session scope</td></tr>
+</tbody>
+</table>
+
+<div class="note">
+<b>Health Metrics:</b> local stdio wiring (<code>lib/iwiki/mcp.sh</code>) не тронут —
+вне диффа; <code>tests/test_iwiki_mcp.sh</code> 23/23 зелёный; секреты не попадают в
+вывод хука — хук читает только <code>process.env.IWIKI_REMOTE_URL</code>, не печатает
+URL/токен (тест <code>t_remote_no_secrets</code>); обычный (non-remote) запуск не
+добавляет оверхеда — хук печатает <code>OK</code>.
+</div>
+
+<div class="note">
+<b>Excess changes:</b> нет. Все 4 изменённых файла привязаны к Stop Rules intent-документа
+(реализация + тест + документация).
+</div>
+
+<p><b>Итоговый вердикт:</b> <span class="badge ok">OK</span> — 0 MISSING, 0 CRITICAL.</p>
+
+<h2>4. Влияние на систему</h2>
+<table>
+<thead><tr><th>Компонент / файл</th><th>Поведенческое изменение</th><th>Риски / follow-up</th></tr></thead>
+<tbody>
+<tr><td><code>lib/iwiki/mcp.sh</code> (выбор remote/stdio)</td><td>Не изменён, но теперь дополняется хуком на уровне <code>additionalContext</code></td><td>Хук и <code>.iwiki.toml</code>-выбор независимы — риск рассинхронизации при будущем изменении механизма registration</td></tr>
+<tr><td><code>.claude-isolated/settings.json</code> → <code>SessionStart</code></td><td>Добавлена вторая hooks-группа</td><td>Порядок хуков (<code>caveman-activate</code> → <code>iwiki-remote-scope</code>) и конкатенация <code>additionalContext</code> не проверены на реальном запуске Claude Code — только unit-вызов node-скрипта напрямую</td></tr>
+<tr><td>iwiki MCP сервер (bearer-token grants)</td><td>Не менялся, остаётся абсолютным пределом авторизации</td><td>Нет автоматического E2E-теста реального сценария <code>wiki_bind</code>/403 — только текстовая инструкция для агента</td></tr>
+</tbody>
+</table>
+
+<h2>5. Схемы</h2>
+<p class="lead">Новый компонент (хук) и новая dependency-связь (settings.json → hook script → agent instruction flow).</p>
+<div class="diagram-wrap">
+<svg viewBox="0 0 1040 460" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="var(--line)"></path>
+    </marker>
+    <filter id="ds" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="2" stdDeviation="3" flood-color="var(--shadow)"></feDropShadow>
+    </filter>
+  </defs>
+
+  <!-- SessionStart -->
+  <rect x="20" y="20" width="180" height="60" rx="8" fill="var(--surface)" stroke="var(--border)" filter="url(#ds)"></rect>
+  <text x="110" y="45" text-anchor="middle" font-weight="600">SessionStart</text>
+  <text x="110" y="63" text-anchor="middle" class="muted-text">settings.json hooks[]</text>
+
+  <!-- hook script -->
+  <rect x="260" y="20" width="220" height="60" rx="8" fill="var(--surface)" stroke="var(--accent)" filter="url(#ds)"></rect>
+  <text x="370" y="45" text-anchor="middle" font-weight="600">iwiki-remote-scope.js</text>
+  <text x="370" y="63" text-anchor="middle" class="muted-text">env-check IWIKI_REMOTE_URL</text>
+
+  <line x1="200" y1="50" x2="255" y2="50" stroke="var(--line)" stroke-width="2" marker-end="url(#arrow)"></line>
+
+  <!-- branch stdio -->
+  <rect x="560" y="0" width="200" height="55" rx="8" fill="var(--zebra)" stroke="var(--border)"></rect>
+  <text x="660" y="22" text-anchor="middle" font-weight="600">stdio / unset</text>
+  <text x="660" y="40" text-anchor="middle" class="muted-text">выводит "OK", молчит</text>
+  <line x1="480" y1="35" x2="555" y2="27" stroke="var(--line)" stroke-width="2" marker-end="url(#arrow)"></line>
+
+  <!-- branch remote -->
+  <rect x="560" y="70" width="220" height="70" rx="8" fill="var(--surface)" stroke="var(--accent)" filter="url(#ds)"></rect>
+  <text x="670" y="93" text-anchor="middle" font-weight="600">remote (URL задан)</text>
+  <text x="670" y="111" text-anchor="middle" class="muted-text">managed-регион в</text>
+  <text x="670" y="126" text-anchor="middle" class="muted-text">additionalContext</text>
+  <line x1="480" y1="65" x2="555" y2="95" stroke="var(--line)" stroke-width="2" marker-end="url(#arrow)"></line>
+
+  <!-- agent -->
+  <rect x="420" y="200" width="200" height="60" rx="8" fill="var(--surface)" stroke="var(--border)" filter="url(#ds)"></rect>
+  <text x="520" y="225" text-anchor="middle" font-weight="600">Агент</text>
+  <text x="520" y="243" text-anchor="middle" class="muted-text">читает additionalContext</text>
+  <line x1="670" y1="140" x2="560" y2="198" stroke="var(--line)" stroke-width="2" marker-end="url(#arrow)"></line>
+
+  <!-- toml -->
+  <rect x="180" y="200" width="200" height="60" rx="8" fill="var(--zebra)" stroke="var(--border)"></rect>
+  <text x="280" y="225" text-anchor="middle" font-weight="600">.iwiki.toml проекта</text>
+  <text x="280" y="243" text-anchor="middle" class="muted-text">read / write / primary</text>
+  <line x1="380" y1="230" x2="415" y2="230" stroke="var(--line)" stroke-width="2" marker-end="url(#arrow)"></line>
+
+  <!-- wiki_bind -->
+  <rect x="380" y="300" width="280" height="60" rx="8" fill="var(--surface)" stroke="var(--accent)" filter="url(#ds)"></rect>
+  <text x="520" y="325" text-anchor="middle" font-weight="600">wiki_bind(read, write, primary)</text>
+  <text x="520" y="343" text-anchor="middle" class="muted-text">до первого wiki-вызова</text>
+  <line x1="520" y1="260" x2="520" y2="298" stroke="var(--line)" stroke-width="2" marker-end="url(#arrow)"></line>
+
+  <!-- server -->
+  <rect x="380" y="390" width="280" height="60" rx="8" fill="var(--surface)" stroke="var(--border)" filter="url(#ds)"></rect>
+  <text x="520" y="415" text-anchor="middle" font-weight="600">iwiki MCP сервер</text>
+  <text x="520" y="433" text-anchor="middle" class="muted-text">bearer-token grant = потолок; 403 при выходе за grant</text>
+  <line x1="520" y1="360" x2="520" y2="388" stroke="var(--line)" stroke-width="2" marker-end="url(#arrow)"></line>
+
+  <!-- wiki calls -->
+  <rect x="720" y="300" width="280" height="150" rx="8" fill="var(--zebra)" stroke="var(--border)"></rect>
+  <text x="860" y="325" text-anchor="middle" font-weight="600">wiki_status / wiki_search /</text>
+  <text x="860" y="343" text-anchor="middle" font-weight="600">task-ledger / прочие вызовы</text>
+  <text x="860" y="365" text-anchor="middle" class="muted-text">только после успешного bind</text>
+  <line x1="660" y1="330" x2="715" y2="330" stroke="var(--line)" stroke-width="2" marker-end="url(#arrow)"></line>
+</svg>
+</div>
+
+</main>
+</body>
+</html>

--- a/tests/test_iwiki_remote_scope.sh
+++ b/tests/test_iwiki_remote_scope.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# Tests for hooks/iwiki-remote-scope.js: the SessionStart preflight that tells
+# the agent to bind the project .iwiki.toml scope before any wiki call under
+# a remote (Streamable HTTP) iwiki MCP server, and stays silent under stdio.
+# Run: bash tests/test_iwiki_remote_scope.sh
+set -u
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+HOOKS_DIR="$REPO_ROOT/.nvm-isolated/.claude-isolated/hooks"
+HOOK="$HOOKS_DIR/iwiki-remote-scope.js"
+
+FAILED=0
+pass() { echo "  PASS: $1"; }
+fail() { echo "  FAIL: $1"; FAILED=1; }
+
+# ---- stdio / unset: no managed region emitted ----
+t_stdio_silent() {
+  echo "[stdio] no IWIKI_REMOTE_URL -> no remote-scope region"
+  local out
+  out="$(env -u IWIKI_REMOTE_URL node "$HOOK")"
+  if [[ "$out" == *"Remote iwiki project scope"* ]]; then
+    fail "region absent under stdio"
+  else
+    pass "region absent under stdio"
+  fi
+}
+t_stdio_silent
+
+# ---- remote: managed region emitted with the preflight instruction ----
+t_remote_region() {
+  echo "[remote] IWIKI_REMOTE_URL set -> remote-scope region emitted"
+  local out
+  out="$(IWIKI_REMOTE_URL="https://iwiki.example.com/mcp" node "$HOOK")"
+  if [[ "$out" == *"## Remote iwiki project scope"* ]]; then
+    pass "region header present"
+  else
+    fail "region header present"
+  fi
+  if [[ "$out" == *"wiki_bind"* && "$out" == *"read"* && "$out" == *"write"* && "$out" == *"primary"* ]]; then
+    pass "instructs wiki_bind with read/write/primary"
+  else
+    fail "instructs wiki_bind with read/write/primary"
+  fi
+  if [[ "$out" == *"before"*"wiki_status"* ]]; then
+    pass "orders bind before wiki_status"
+  else
+    fail "orders bind before wiki_status"
+  fi
+  if [[ "$out" == *"completion-pending"* && "$out" == *"403"* ]]; then
+    pass "fail-closed on invalid scope / 403"
+  else
+    fail "fail-closed on invalid scope / 403"
+  fi
+}
+t_remote_region
+
+# ---- remote output never contains the URL/token themselves ----
+t_remote_no_secrets() {
+  echo "[remote] emitted region carries no URL or token"
+  local out
+  out="$(IWIKI_REMOTE_URL="https://iwiki.example.com/mcp" IWIKI_REMOTE_TOKEN="sk-secret-token" node "$HOOK")"
+  if [[ "$out" == *"iwiki.example.com"* || "$out" == *"sk-secret-token"* ]]; then
+    fail "no secret/URL leakage in emitted text"
+  else
+    pass "no secret/URL leakage in emitted text"
+  fi
+}
+t_remote_no_secrets
+
+# ---- idempotent: identical output across repeated invocations ----
+t_idempotent() {
+  echo "[remote] repeated invocations emit identical output"
+  local out1 out2
+  out1="$(IWIKI_REMOTE_URL="https://iwiki.example.com/mcp" node "$HOOK")"
+  out2="$(IWIKI_REMOTE_URL="https://iwiki.example.com/mcp" node "$HOOK")"
+  if [[ "$out1" == "$out2" ]]; then
+    pass "idempotent output"
+  else
+    fail "idempotent output"
+  fi
+}
+t_idempotent
+
+echo "iwiki-remote-scope: FAILED=$FAILED"
+exit "$FAILED"


### PR DESCRIPTION
## Summary
- Under a hosted (Streamable HTTP) iwiki MCP server, the agent must apply the project's own `.iwiki.toml` scope via `wiki_bind` before any wiki call, rather than relying on the bearer token's default scope.
- Adds `hooks/iwiki-remote-scope.js`, a SessionStart hook that emits this preflight instruction only when `IWIKI_REMOTE_URL` is set; local stdio mode is unaffected (server resolves the binding itself).
- Ports the icodex `remote-iwiki-project-scope` contract; server-side authorization (bearer-token grants, iwiki-mcp itself) is unmodified.

## Test plan
- [x] `bash tests/test_iwiki_remote_scope.sh` — 4/4 pass (stdio silent, remote region content, no secret leakage, idempotency)
- [x] `bash tests/test_iwiki_mcp.sh` — 23/23 pass (regression, unaffected)
- [x] `bash tests/test_env_map.sh`, `test_caveman_*.sh` — green (regression, `settings.json` touched)
- [x] `/check-chain intent` — OK, 5/5 phases
- [x] `/check-chain result` — OK, 0 MISSING/CRITICAL — report: `docs/superpowers/reports/remote-iwiki-project-scope-results.html`

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>