### PR TITLE
fix(statusline): correct Opus 5 context window and repair rate-limit display

### DIFF
--- a/.nvm-isolated/.claude-isolated/scripts/claude-statusline.sh
+++ b/.nvm-isolated/.claude-isolated/scripts/claude-statusline.sh
@@ -146,7 +146,7 @@ detect_real_context_window() {
         *opus*|*sonnet*)
             case "${model,,}" in
                 *4-8*|*4.8*|*4-7*|*4.7*|*4-6*|*4.6*|*4-5*|*4.5*) known=1000000 ;;  # 1M
-                *sonnet?5*) known=1000000 ;;                      # Sonnet 5 = 1M ("5" right after "sonnet"; not "Sonnet 3.5")
+                *sonnet?5*|*opus?5*) known=1000000 ;;             # Sonnet 5 / Opus 5 = 1M ("5" right after model name; not "Sonnet 3.5")
                 *) known=0 ;;                                     # 4.0/4.1 → reported
             esac ;;
     esac
@@ -843,6 +843,17 @@ else
     fi
 fi
 
+# Auto-compact proximity warning.
+# Anthropic doesn't publish the exact auto-compact trigger percentage (it has
+# shifted across releases, unofficially ~92-95%); CLAUDE_AUTOCOMPACT_PCT_OVERRIDE
+# lets users override it. Default 92 is an estimate, not a guarantee.
+COMPACT_ICON=""
+_COMPACT_THRESHOLD="${CLAUDE_AUTOCOMPACT_PCT_OVERRIDE:-92}"
+[[ "$_COMPACT_THRESHOLD" =~ ^[0-9]+$ ]] || _COMPACT_THRESHOLD=92
+if [[ "${ACTIVE_PERCENT_INT:-0}" -ge "$_COMPACT_THRESHOLD" ]]; then
+    COMPACT_ICON=" 🗜️~${_COMPACT_THRESHOLD}%"
+fi
+
 # CRITICAL: Clean ALL variables from newlines BEFORE assembly
 # Problem: Newlines appear in multiple places, not just format_tokens
 TOTAL_TOKENS_FMT=$(printf '%s' "$TOTAL_TOKENS_FMT" | tr -d '\n\r')
@@ -854,9 +865,9 @@ CACHE_FMT=$(printf '%s' "${CACHE_FMT:-}" | tr -d '\n\r')
 # Format: Σ 680K ↓ | 📊 320K (32%)
 if [[ $ACTIVE_TOKENS -gt 0 ]]; then
     if [[ $ACTIVE_TOKENS -gt $CONTEXT_LIMIT ]]; then
-        CONTEXT_DISPLAY="Σ ${REMAINING_FMT} ↓ | ${ACTIVE_COLOR}📊 ${ACTIVE_TOKENS_FMT} (${EFFECTIVE_PERCENT}%)${RESET} ⚠️"
+        CONTEXT_DISPLAY="Σ ${REMAINING_FMT} ↓ | ${ACTIVE_COLOR}📊 ${ACTIVE_TOKENS_FMT} (${EFFECTIVE_PERCENT}%)${RESET} ⚠️${COMPACT_ICON}"
     else
-        CONTEXT_DISPLAY="Σ ${REMAINING_FMT} ↓ | ${ACTIVE_COLOR}📊 ${ACTIVE_TOKENS_FMT} (${EFFECTIVE_PERCENT}%)${RESET}"
+        CONTEXT_DISPLAY="Σ ${REMAINING_FMT} ↓ | ${ACTIVE_COLOR}📊 ${ACTIVE_TOKENS_FMT} (${EFFECTIVE_PERCENT}%)${RESET}${COMPACT_ICON}"
     fi
 else
     # Zero active tokens (after /clear)

--- a/.nvm-isolated/.claude-isolated/scripts/lib/rate-limit.sh
+++ b/.nvm-isolated/.claude-isolated/scripts/lib/rate-limit.sh
@@ -1,20 +1,24 @@
 #!/bin/bash
 # Rate Limit Module for Claude Code Statusline
-# Fetches and caches Anthropic API rate limit info (unified 5h window)
+# Fetches and caches Anthropic API rate limit info (unified 5h + 7d windows)
 #
 # API: POST https://api.anthropic.com/v1/messages (max_tokens:1, "quota")
 #   - Costs 1 output token per call (~$0.00002) — minimal but not free
 #   - Returns headers:
 #     anthropic-ratelimit-unified-5h-utilization  (float 0.0-1.0)
 #     anthropic-ratelimit-unified-5h-reset         (unix timestamp, seconds)
+#     anthropic-ratelimit-unified-7d-utilization  (float 0.0-1.0)
+#     anthropic-ratelimit-unified-7d-reset         (unix timestamp, seconds)
 #
 # Auth: OAuth Bearer token + anthropic-beta: oauth-2025-04-20
-#       Token from $CLAUDE_CONFIG_DIR/.credentials.json
+#       Token from $CLAUDE_CODE_OAUTH_TOKEN (long-lived `claude setup-token`,
+#       set via .claude_config in iclaude setups) if set, else
+#       $CLAUDE_CONFIG_DIR/.credentials.json
 # Cache: /tmp/claude-ratelimit-cache.json  (TTL 60 seconds)
 # Async: Background curl — never blocks statusline render
 #
 # Public functions:
-#   get_rate_limit_display()              → prints "[RL:45% 2h30m]" or ""
+#   get_rate_limit_display()              → prints "[RL:45% 2h30m | 7d 12% 3d]" or ""
 #   trigger_rate_limit_fetch <config_dir> → fires background curl, returns immediately
 
 # Read cached rate limit and return formatted display string.
@@ -32,10 +36,12 @@ get_rate_limit_display() {
     [[ -z "$cache_json" ]] && return 0
 
     # Parse fields with jq
-    local utilization cached_at reset_at
+    local utilization cached_at reset_at util_7d reset_7d
     utilization=$(echo "$cache_json" | jq -r '.utilization // empty' 2>/dev/null)
     cached_at=$(echo "$cache_json" | jq -r '.cached_at // 0' 2>/dev/null)
     reset_at=$(echo "$cache_json" | jq -r '.reset_at // 0' 2>/dev/null)
+    util_7d=$(echo "$cache_json" | jq -r '.utilization_7d // empty' 2>/dev/null)
+    reset_7d=$(echo "$cache_json" | jq -r '.reset_at_7d // 0' 2>/dev/null)
 
     # Validate non-empty
     [[ -z "$utilization" ]] && return 0
@@ -81,7 +87,35 @@ get_rate_limit_display() {
     fi
     local rl_reset=$'\033[0m'
 
-    printf '%s[RL:%d%% %s]%s' "$rl_color" "$pct" "$time_str" "$rl_reset"
+    # Optional 7-day (weekly) window — same call, no extra API cost
+    local week_str=""
+    if [[ -n "$util_7d" ]] && [[ "$util_7d" =~ ^[0-9]+\.?[0-9]*$ ]] && \
+       [[ -n "$reset_7d" ]] && [[ "$reset_7d" != "0" ]]; then
+        local pct_7d delta_7d days_7d time_7d
+        pct_7d=$(awk "BEGIN{printf \"%.0f\", $util_7d * 100}")
+        delta_7d=$((reset_7d - now))
+        if [[ $delta_7d -le 0 ]]; then
+            time_7d="reset"
+        else
+            days_7d=$((delta_7d / 86400))
+            if [[ $days_7d -gt 0 ]]; then
+                time_7d="${days_7d}d"
+            else
+                time_7d="$(( (delta_7d % 86400) / 3600 ))h"
+            fi
+        fi
+        local color_7d
+        if [[ $pct_7d -lt 50 ]]; then
+            color_7d=$'\033[32m'
+        elif [[ $pct_7d -lt 80 ]]; then
+            color_7d=$'\033[33m'
+        else
+            color_7d=$'\033[31m'
+        fi
+        week_str=$(printf ' %s7d:%d%% %s%s' "$color_7d" "$pct_7d" "$time_7d" "$rl_reset")
+    fi
+
+    printf '%s[RL:%d%% %s]%s%s' "$rl_color" "$pct" "$time_str" "$rl_reset" "$week_str"
     return 0
 }
 
@@ -122,6 +156,10 @@ trigger_rate_limit_fetch() {
 
     # Capture for subshell
     local creds_file="$config_dir/.credentials.json"
+    # iclaude setups commonly authenticate via CLAUDE_CODE_OAUTH_TOKEN (long-lived
+    # token from `claude setup-token`, see lib/oauth/token.sh) instead of an
+    # interactive login — no .credentials.json file is ever written in that case.
+    local env_token="${CLAUDE_CODE_OAUTH_TOKEN:-}"
 
     # Background fetch — fire and forget
     (
@@ -131,15 +169,19 @@ trigger_rate_limit_fetch() {
         }
         trap cleanup_rl EXIT
 
-        [[ ! -f "$creds_file" ]] && exit 0
-
-        local token
-        token=$(jq -r '.claudeAiOauth.accessToken // empty' "$creds_file" 2>/dev/null)
+        local token="$env_token"
+        if [[ -z "$token" ]]; then
+            [[ ! -f "$creds_file" ]] && exit 0
+            token=$(jq -r '.claudeAiOauth.accessToken // empty' "$creds_file" 2>/dev/null)
+        fi
         [[ -z "$token" ]] && exit 0
 
         # POST /v1/messages with max_tokens:1 — same method Claude Code uses internally
         # Requires anthropic-beta: oauth-2025-04-20 to allow OAuth Bearer token
-        local body='{"model":"claude-sonnet-4-6","max_tokens":1,"messages":[{"role":"user","content":"quota"}]}'
+        # Model must be a currently valid id — an unknown/retired id returns 429
+        # rate_limit_error with NO anthropic-ratelimit-unified-* headers at all,
+        # silently breaking this fetch. Haiku 4.5 is the cheapest current model.
+        local body='{"model":"claude-haiku-4-5-20251001","max_tokens":1,"messages":[{"role":"user","content":"quota"}]}'
         local headers_file="/tmp/claude-ratelimit-headers-$$.tmp"
 
         curl -s \
@@ -157,10 +199,14 @@ trigger_rate_limit_fetch() {
 
         [[ ! -f "$headers_file" ]] && exit 0
 
-        local utilization reset_at
+        local utilization reset_at util_7d reset_7d
         utilization=$(grep -i "anthropic-ratelimit-unified-5h-utilization:" "$headers_file" \
                       | awk '{print $2}' | tr -d '\r\n')
         reset_at=$(grep -i "anthropic-ratelimit-unified-5h-reset:" "$headers_file" \
+                   | awk '{print $2}' | tr -d '\r\n')
+        util_7d=$(grep -i "anthropic-ratelimit-unified-7d-utilization:" "$headers_file" \
+                  | awk '{print $2}' | tr -d '\r\n')
+        reset_7d=$(grep -i "anthropic-ratelimit-unified-7d-reset:" "$headers_file" \
                    | awk '{print $2}' | tr -d '\r\n')
 
         [[ -z "$utilization" ]] && exit 0
@@ -168,11 +214,16 @@ trigger_rate_limit_fetch() {
         [[ ! "$utilization" =~ ^[0-9]+\.?[0-9]*$ ]] && exit 0
         [[ ! "$reset_at" =~ ^[0-9]+$ ]] && exit 0
 
+        # 7d fields are optional — blank out on any validation failure
+        [[ ! "$util_7d" =~ ^[0-9]+\.?[0-9]*$ ]] && util_7d=""
+        [[ ! "$reset_7d" =~ ^[0-9]+$ ]] && reset_7d=""
+
         local now
         now=$(date +%s)
         local tmp_cache="/tmp/claude-ratelimit-cache.json.$$.tmp"
-        printf '{"utilization":%s,"reset_at":%s,"cached_at":%s}\n' \
-            "$utilization" "$reset_at" "$now" > "$tmp_cache" && \
+        printf '{"utilization":%s,"reset_at":%s,"cached_at":%s,"utilization_7d":%s,"reset_at_7d":%s}\n' \
+            "$utilization" "$reset_at" "$now" \
+            "${util_7d:-null}" "${reset_7d:-null}" > "$tmp_cache" && \
             mv "$tmp_cache" "/tmp/claude-ratelimit-cache.json"
 
         exit 0

--- a/docs/functions/STATUSLINE.md
+++ b/docs/functions/STATUSLINE.md
@@ -588,6 +588,21 @@ Format: `🧠` - clickable hyperlink (OSC 8)
 
 Branch name + uncommitted changes count (e.g., "master" or "feature-branch +3")
 
+### 10. Rate Limit
+
+Format: `[RL:45% 2h30m 7d:62% 3d]` — Anthropic-only (hidden with `--router`).
+
+- Read from `anthropic-ratelimit-unified-5h-*` and `anthropic-ratelimit-unified-7d-*`
+  response headers, fetched via a single minimal `POST /v1/messages` call
+  (`lib/rate-limit.sh`) and cached for 60s (5-minute hard expiry for display).
+- Auth for that call: `$CLAUDE_CODE_OAUTH_TOKEN` if set (long-lived `claude setup-token`,
+  set via `.claude_config` → `ICLAUDE_CLAUDE_CODE_OAUTH_TOKEN` in iclaude setups), else
+  `$CLAUDE_CONFIG_DIR/.credentials.json`. Silently shows nothing if neither is available
+  (e.g. auth stored in an OS keychain the module doesn't read).
+- First segment is the 5-hour session window; `7d:` is the weekly window, shown only
+  when the API returns it. Colored green (<50%), yellow (50-79%), red (≥80%) per window.
+- Time shown is time-to-reset (`2h30m` for 5h, `3d` for 7d).
+
 ## Features
 
 ### Key Capabilities
@@ -610,13 +625,17 @@ The status line automatically adapts to terminal width to prevent line wrapping 
 
 `detect_real_context_window()` resolves the true window **by model name**, because
 Claude Code reports `context_window_size: 200000` even for 1M-window models
-(Opus/Sonnet 4.x). Mapping: Opus/Sonnet 4.5+ → 1M, Haiku → 200K, unknown → reported.
+(Opus/Sonnet 4.x). Mapping: Opus 5, Sonnet 5, Opus/Sonnet 4.5+ → 1M, Haiku → 200K,
+Fable/Mythos → 1M, unknown → reported.
 
 - **Σ** — remaining tokens until the window is full (`window − active`), e.g. `Σ 680K ↓`.
 - **📊** — active context (real `total_input_tokens`, incl. cache) and its % of the
   full window, e.g. `📊 320K (32%)`. `⚠️` appended if active exceeds the window.
   Derived from real token counts, **not** from `used_percentage` (which Claude Code
-  saturates at 100 against its stale 200K value).
+  saturates at 100 against its stale 200K value). A `🗜️~92%` marker is appended once
+  active usage reaches the estimated auto-compact threshold (Anthropic doesn't publish
+  the exact trigger, so this defaults to 92% and can be overridden with
+  `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE`).
 - **📦** — cache hit-rate % and read/write split, e.g. `📦 86% · R310K/W10K` (`R` = cache_read, `W` = cache_creation; hit-rate = read / (read + creation + input)).
 
 The fixed `🔒 45K` reserved-buffer marker was removed — it was meaningless at 1M.

--- a/iclaude.sh
+++ b/iclaude.sh
@@ -719,6 +719,11 @@ fi
         disable_auto_updates
     fi
 
+    # Materialize CLAUDE_CODE_OAUTH_TOKEN to .credentials.json (best-effort, no-op
+    # if already present or no env token) — lets statusline rate-limit fetch read
+    # the token from disk, since Claude Code doesn't pass env vars to hooks.
+    materialize_oauth_credentials "$CLAUDE_CONFIG_DIR"
+
     echo ""
     echo "═══════════════════════════════════════"
     echo "  Claude Code Proxy Initializer v2.0"

--- a/lib/oauth/token.sh
+++ b/lib/oauth/token.sh
@@ -264,3 +264,41 @@ validate_jq_installed() {
     # Delegated to core/validation.sh
     validate_dependency "jq" "Install jq: sudo apt-get install jq (Debian/Ubuntu) or brew install jq (macOS)"
 }
+
+#######################################
+# Materialize CLAUDE_CODE_OAUTH_TOKEN into .credentials.json
+# Claude Code doesn't propagate env vars like CLAUDE_CODE_OAUTH_TOKEN into
+# spawned hook/statusline processes, so tooling that reads the token from a
+# file (e.g. the statusline's rate-limit fetch) sees nothing when auth comes
+# from the env var (claude setup-token / .claude_config) instead of an
+# interactive `claude login`. Writing the token to the standard credentials
+# file location closes that gap without changing how Claude Code itself
+# authenticates.
+# Arguments:
+#   $1 - config directory (defaults to CLAUDE_CONFIG_DIR, then $HOME/.claude)
+# Returns:
+#   0 - always (best-effort; never blocks startup)
+#######################################
+materialize_oauth_credentials() {
+    local config_dir="${1:-${CLAUDE_CONFIG_DIR:-$HOME/.claude}}"
+
+    [[ -z "${CLAUDE_CODE_OAUTH_TOKEN:-}" ]] && return 0
+    command -v jq &>/dev/null || return 0
+    [[ -d "$config_dir" ]] || return 0
+
+    local credentials_file="$config_dir/.credentials.json"
+    # Never overwrite an existing file — it may hold a real interactive login
+    # (with refresh token / expiry) that this env-token stub would clobber.
+    [[ -f "$credentials_file" ]] && return 0
+
+    local tmp_file="${credentials_file}.tmp.$$"
+    if jq -n --arg token "$CLAUDE_CODE_OAUTH_TOKEN" \
+        '{claudeAiOauth: {accessToken: $token}}' > "$tmp_file" 2>/dev/null; then
+        chmod 600 "$tmp_file" 2>/dev/null
+        mv "$tmp_file" "$credentials_file" 2>/dev/null
+    else
+        rm -f "$tmp_file"
+    fi
+
+    return 0
+}


### PR DESCRIPTION
## Summary
- `detect_real_context_window()` now maps Opus 5 to the real 1M context window (was falling through to the stale 200K reported value, matching only Sonnet 5 before). Added a `🗜️~92%` auto-compact proximity indicator (threshold unpublished by Anthropic, overridable via `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE`).
- Added the 7-day (weekly) unified rate-limit window to the statusline's `[RL:...]` segment, alongside the existing 5h window — same probe request, no extra API cost.
- Fixed two compounding bugs that silently broke the rate-limit segment in this iclaude env-token setup: an invalid/retired hardcoded probe model id (`claude-sonnet-4-6` → 429 with no usage headers), and `CLAUDE_CODE_OAUTH_TOKEN` never reaching hook/statusline subprocesses (Claude Code doesn't propagate it) — added `materialize_oauth_credentials()` in `lib/oauth/token.sh`, wired into `iclaude.sh` startup, to persist the env token to `.credentials.json` once so those subprocesses can read it.

## Test plan
- [x] `bash -n` on all changed shell scripts
- [x] Mock-session run of `claude-statusline.sh` confirming Opus 5 → 920K/1000000 (92%) and the compact icon
- [x] Direct API probe with the real OAuth token confirming HTTP 200 and full `anthropic-ratelimit-unified-5h-*`/`-7d-*` headers
- [x] Live-verified by the user: the real running statusline renders `[RL:12% 2h03m 7d:12% 5d]` correctly

Task ledger: `iclaude/reference/tasks/statusline-limits-context-window-audit` (iwiki)

🤖 Generated with [Claude Code](https://claude.com/claude-code)