### PR TITLE
fix(iwiki): signal config switch, not toml edit, for code-graph under remote mode

### DIFF
--- a/.nvm-isolated/.claude-isolated/hooks/iwiki-remote-scope.js
+++ b/.nvm-isolated/.claude-isolated/hooks/iwiki-remote-scope.js
@@ -31,5 +31,11 @@ process.stdout.write(
   'domain, or current session scope. On a missing or invalid TOML scope, or a ' +
   'rejected bind such as 403, show a brief reason, do not make mutating wiki ' +
   'calls, and retain task lifecycle `completion-pending`. The remote server\'s ' +
-  'token grants remain the absolute authorization limit.'
+  'token grants remain the absolute authorization limit.\n\n' +
+  '`wiki_code_index` is unavailable under this hosted mode — it needs a local ' +
+  'repository checkout on the server\'s disk, which a remote HTTP server does ' +
+  'not have, so it returns `source_unavailable`. That error means the active ' +
+  'MCP server config must switch to the local stdio one ' +
+  '(`mcp/iwiki.json`, via `IWIKI_COMMAND`/`IWIKI_BASE_DIR`), not that ' +
+  '`.iwiki.toml` needs editing.'
 );

--- a/docs/iwiki-mcp-modes.md
+++ b/docs/iwiki-mcp-modes.md
@@ -48,3 +48,14 @@ under local stdio (no `IWIKI_REMOTE_URL`).
 
 Local stdio does not run this preflight — its project binding is resolved entirely
 server-side from `.iwiki.toml`, as described above.
+
+## Code graph and remote mode
+
+`wiki_code_index` needs a local repository checkout on the server's disk. A hosted
+Streamable HTTP server has no such checkout, so under remote mode it returns
+`{"error":"source_unavailable", ...}`. The `iwiki-remote-scope.js` hook's emitted
+instruction now says this explicitly: that error means the active MCP config must
+switch from `mcp/iwiki-remote.json` to the local stdio one (`mcp/iwiki.json`, via
+`IWIKI_COMMAND`/`IWIKI_BASE_DIR`) and the session restarted — not that `.iwiki.toml`
+needs editing. `publish_mode = "mcp"` in `.iwiki.toml` still applies afterward, to push
+the locally-built snapshot to the hosted server.

--- a/tests/test_iwiki_remote_scope.sh
+++ b/tests/test_iwiki_remote_scope.sh
@@ -51,6 +51,11 @@ t_remote_region() {
   else
     fail "fail-closed on invalid scope / 403"
   fi
+  if [[ "$out" == *"wiki_code_index"* && "$out" == *"source_unavailable"* && "$out" == *"mcp/iwiki.json"* ]]; then
+    pass "notes wiki_code_index needs local stdio config, not .iwiki.toml edit"
+  else
+    fail "notes wiki_code_index needs local stdio config, not .iwiki.toml edit"
+  fi
 }
 t_remote_region
 


### PR DESCRIPTION
## Summary
- wiki_code_index always returns source_unavailable under hosted HTTP iwiki MCP mode — it needs a local repo checkout the server doesn't have.
- iwiki-remote-scope.js SessionStart hook now tells the agent that fix means switching the active MCP config to local stdio (mcp/iwiki.json), not editing .iwiki.toml.
- Docs and test updated to match.

## Known limitation (not fixed by this PR)
This PR only makes the agent aware it must switch config — it does not add a switching mechanism. The underlying gap is architectural: iclaude registers exactly one iwiki MCP transport per session (`lib/iwiki/mcp.sh` picks remote-over-local globally from env, see `_iwiki_remote_selected`), with no per-project selection. A project whose `.iwiki.toml` wants local code-graph indexing still gets whatever transport the session's env resolved to. Fixing this needs an iclaude-level change — per-project transport selection or dual-MCP registration — not an iwiki-mcp change. Filed as a separate follow-up, not in scope here.

## Test plan
- [x] bash tests/test_iwiki_remote_scope.sh (8/8 pass)