### PR TITLE
feat(iwiki): register local + remote MCP servers together for code-graph workflow

### DIFF
--- a/.nvm-isolated/.claude-isolated/hooks/iwiki-remote-scope.js
+++ b/.nvm-isolated/.claude-isolated/hooks/iwiki-remote-scope.js
@@ -19,6 +19,15 @@ if (!process.env.IWIKI_REMOTE_URL) {
   process.exit(0);
 }
 
+// IWIKI_COMMAND is exported by lib/iwiki/mcp.sh's iwiki_resolve_command as a
+// side effect of the launch-time enable gate, so by the time this hook runs
+// (spawned as a child of that same launch) it is present in the environment
+// whenever local mode is also usable. Together with IWIKI_LLM_KEY this
+// mirrors _iwiki_local_selected's conditions closely enough to tell the
+// agent whether it is looking at a dual (mcp/iwiki-dual.json) or a
+// remote-only registration — see lib/iwiki/mcp.sh.
+const dualActive = Boolean(process.env.IWIKI_COMMAND && process.env.IWIKI_LLM_KEY);
+
 process.stdout.write(
   '## Remote iwiki project scope\n\n' +
   'Before the first wiki call, load only `read`, `write`, and `primary` from the ' +
@@ -31,5 +40,18 @@ process.stdout.write(
   'domain, or current session scope. On a missing or invalid TOML scope, or a ' +
   'rejected bind such as 403, show a brief reason, do not make mutating wiki ' +
   'calls, and retain task lifecycle `completion-pending`. The remote server\'s ' +
-  'token grants remain the absolute authorization limit.'
+  'token grants remain the absolute authorization limit.\n\n' +
+  (dualActive
+    ? 'This session has both transports registered: `wiki_code_index`, ' +
+      '`wiki_code_search`, and `wiki_code_context` run on the `iwiki-local` ' +
+      'server (it has the repository checkout); every other wiki tool, ' +
+      'including `wiki_code_publish_begin`/`_batch`/`_finalize`, runs on ' +
+      '`iwiki-remote` as usual. No config switch is needed for either.'
+    : '`wiki_code_index` is unavailable under this hosted-only mode — it needs a ' +
+      'local repository checkout on the server\'s disk, which a remote HTTP ' +
+      'server does not have, so it returns `source_unavailable`. That error ' +
+      'means the active MCP server config must switch to the local stdio one ' +
+      '(`mcp/iwiki.json`, via `IWIKI_COMMAND`/`IWIKI_BASE_DIR`) or add it ' +
+      'alongside this one (`mcp/iwiki-dual.json`) and the session restarted — ' +
+      'not that `.iwiki.toml` needs editing.')
 );

--- a/.nvm-isolated/.claude-isolated/mcp/iwiki-dual.json
+++ b/.nvm-isolated/.claude-isolated/mcp/iwiki-dual.json
@@ -1,0 +1,38 @@
+{
+  "mcpServers": {
+    "iwiki-local": {
+      "type": "stdio",
+      "command": "${IWIKI_COMMAND}",
+      "args": [],
+      "env": {
+        "IWIKI_BASE_DIR":             "${IWIKI_BASE_DIR}",
+        "IWIKI_LLM_BASE_URL":         "${IWIKI_LLM_BASE_URL}",
+        "IWIKI_LLM_KEY":              "${IWIKI_LLM_KEY}",
+        "IWIKI_DB_PASSWORD":          "${IWIKI_DB_PASSWORD:-}",
+        "IWIKI_EMBED_MODEL":          "${IWIKI_EMBED_MODEL:-text-embedding-3-small}",
+        "IWIKI_EMBED_DIMENSIONS":     "${IWIKI_EMBED_DIMENSIONS:-1536}",
+        "IWIKI_CHAT_MODEL":           "${IWIKI_CHAT_MODEL:-}",
+        "IWIKI_RERANK_MODEL":         "${IWIKI_RERANK_MODEL:-}",
+        "IWIKI_IDLE_TIMEOUT_SECONDS": "${IWIKI_IDLE_TIMEOUT_SECONDS:-86400}",
+        "IWIKI_CHUNK_SIZE":           "${IWIKI_CHUNK_SIZE:-512}",
+        "IWIKI_CHUNK_OVERLAP":        "${IWIKI_CHUNK_OVERLAP:-64}",
+        "IWIKI_SUMMARY_MAX_CHARS":    "${IWIKI_SUMMARY_MAX_CHARS:-400}",
+        "IWIKI_SEARCH_MODE":          "${IWIKI_SEARCH_MODE:-hybrid}",
+        "IWIKI_TOP_K":                "${IWIKI_TOP_K:-8}",
+        "IWIKI_SCORE_THRESHOLD":      "${IWIKI_SCORE_THRESHOLD:-0.2}",
+        "IWIKI_GRAPH_DEPTH":          "${IWIKI_GRAPH_DEPTH:-2}",
+        "IWIKI_SEED_TOP_K":           "${IWIKI_SEED_TOP_K:-5}",
+        "IWIKI_BFS_TOP_K":            "${IWIKI_BFS_TOP_K:-10}",
+        "IWIKI_SEED_THRESHOLD":       "${IWIKI_SEED_THRESHOLD:-0.15}",
+        "IWIKI_WRITE_SEED_THRESHOLD": "${IWIKI_WRITE_SEED_THRESHOLD:-0.35}"
+      }
+    },
+    "iwiki-remote": {
+      "type": "http",
+      "url": "${IWIKI_REMOTE_URL}",
+      "headers": {
+        "Authorization": "Bearer ${IWIKI_REMOTE_TOKEN}"
+      }
+    }
+  }
+}

--- a/docs/iwiki-mcp-modes.md
+++ b/docs/iwiki-mcp-modes.md
@@ -23,9 +23,10 @@ ICLAUDE_IWIKI_REMOTE_TOKEN="<bearer-token>"
 
 When `IWIKI_REMOTE_URL` is set, `lib/iwiki/mcp.sh` selects the remote registration
 (`mcp/iwiki-remote.json`, type `http`, `Authorization: Bearer ${IWIKI_REMOTE_TOKEN}`)
-over the local stdio server. The token is mapped only at runtime via env-map
-(`ICLAUDE_IWIKI_REMOTE_TOKEN` → `IWIKI_REMOTE_TOKEN`), never written to any tracked
-config file.
+over the local stdio server — unless local is *also* usable, in which case both are
+registered at once (see [Dual mode](#dual-mode-local--remote-at-once) below). The token
+is mapped only at runtime via env-map (`ICLAUDE_IWIKI_REMOTE_TOKEN` → `IWIKI_REMOTE_TOKEN`),
+never written to any tracked config file.
 
 The hosted server resolves wiki identity and its own read/write grants from the bearer
 token — that grant remains the absolute authorization ceiling. But the client project can
@@ -48,3 +49,33 @@ under local stdio (no `IWIKI_REMOTE_URL`).
 
 Local stdio does not run this preflight — its project binding is resolved entirely
 server-side from `.iwiki.toml`, as described above.
+
+## Dual mode (local + remote at once)
+
+`wiki_code_index` needs a local repository checkout on the server's disk, so it always
+returns `source_unavailable` under remote-only mode; `wiki_code_publish_begin`/`_batch`/
+`_finalize` need a hosted authenticated transit, so they always return
+`unsupported_storage` under local-only mode. Building a code graph locally and then
+publishing it needs both in the same session.
+
+When both local (`IWIKI_COMMAND` resolvable, `IWIKI_LLM_KEY` set) and remote
+(`IWIKI_REMOTE_URL` + `IWIKI_REMOTE_TOKEN`) are usable, `lib/iwiki/mcp.sh` registers the
+tracked `.nvm-isolated/.claude-isolated/mcp/iwiki-dual.json` instead of either single
+config. It declares two distinct servers in one `--mcp-config`:
+
+- `iwiki-local` — the same stdio registration as single-local mode, so
+  `wiki_code_index`, `wiki_code_search`, and `wiki_code_context` run against this
+  project's own checkout. Optional `IWIKI_CODE_GRAPH_*` overrides still splice into its
+  `env` object exactly as in single-local mode.
+- `iwiki-remote` — the same hosted HTTP registration as single-remote mode, for every
+  other wiki tool, including `wiki_code_publish_begin`/`_batch`/`_finalize`.
+
+Single-local-only and single-remote-only sessions are unaffected: they keep registering
+under the plain server name `iwiki` from `mcp/iwiki.json` / `mcp/iwiki-remote.json`, byte
+for byte as before. Dual mode is a distinct third tracked file, never a rename of either.
+
+`hooks/iwiki-remote-scope.js` detects this at session start (via `IWIKI_COMMAND` and
+`IWIKI_LLM_KEY` also being present alongside `IWIKI_REMOTE_URL`) and tells the agent to
+route code-graph tools to `iwiki-local` and everything else to `iwiki-remote` — no config
+switch needed. Under remote-only mode it still tells the agent that `source_unavailable`
+means switching (or adding) the local config, not editing `.iwiki.toml`.

--- a/docs/superpowers/intents/2026-08-17-iwiki-dual-mcp-registration-intent.md
+++ b/docs/superpowers/intents/2026-08-17-iwiki-dual-mcp-registration-intent.md
@@ -1,3 +1,15 @@
+---
+review:
+  intent_hash: c8d088abafde6458
+  last_run: 2026-08-17
+  phases:
+    structure: {status: passed, findings: []}
+    completeness: {status: passed, findings: []}
+    clarity: {status: passed, findings: []}
+    consistency: {status: passed, findings: []}
+    alignment: {status: passed, findings: []}
+---
+
 # Intent: iwiki-dual-mcp-registration
 
 **Date:** 2026-08-17

--- a/docs/superpowers/intents/2026-08-17-iwiki-dual-mcp-registration-intent.md
+++ b/docs/superpowers/intents/2026-08-17-iwiki-dual-mcp-registration-intent.md
@@ -8,6 +8,10 @@ review:
     clarity: {status: passed, findings: []}
     consistency: {status: passed, findings: []}
     alignment: {status: passed, findings: []}
+result_check:
+  verdict: OK
+  intent_hash: c8d088abafde6458
+  last_run: 2026-08-17
 ---
 
 # Intent: iwiki-dual-mcp-registration

--- a/docs/superpowers/intents/2026-08-17-iwiki-dual-mcp-registration-intent.md
+++ b/docs/superpowers/intents/2026-08-17-iwiki-dual-mcp-registration-intent.md
@@ -1,0 +1,88 @@
+# Intent: iwiki-dual-mcp-registration
+
+**Date:** 2026-08-17
+**Status:** approved
+
+## Objective
+iclaude currently registers exactly one iwiki MCP server per session (`lib/iwiki/mcp.sh`'s
+`iwiki_mcp_enabled` / `_iwiki_remote_selected` picks remote over local exclusively). This
+breaks the code-graph workflow: `wiki_code_index` needs a local repository checkout, so it
+always returns `source_unavailable` under remote (hosted HTTP) mode; `wiki_code_publish_*`
+needs a hosted authenticated transit, so it returns `unsupported_storage` under local
+(stdio) mode. Build a code graph locally, then publish it to a hosted server — that
+sequence is currently impossible within one session. Support running the code-graph build
+and its MCP publication at the same time, now.
+
+## Desired Outcomes
+- In a session with both local (`IWIKI_COMMAND`/`IWIKI_LLM_KEY`) and remote
+  (`IWIKI_REMOTE_URL`/`IWIKI_REMOTE_TOKEN`) configured, `wiki_code_index` no longer fails
+  with `source_unavailable` — it builds the graph locally.
+- In the same session, `wiki_code_publish_begin`/`_batch`/`_finalize` successfully push the
+  built snapshot to the hosted server.
+- Existing content tools (`wiki_search`, `wiki_read_page`, task-ledger writes, etc.)
+  continue to route through remote/primary as before — no regression.
+- Sessions with only local or only remote configured behave exactly as they do today
+  (single-server, unchanged).
+
+## Health Metrics
+- `lib/iwiki/mcp.sh` enable gate: single-server sessions (local-only or remote-only)
+  behave identically to today; `tests/test_iwiki_mcp.sh` stays green with its existing
+  single-mode assertions unchanged.
+- `hooks/iwiki-remote-scope.js`: remote-only sessions still get the same preflight
+  instruction as today; `tests/test_iwiki_remote_scope.sh` does not regress.
+- Existing task-ledger workflow (`wiki_bind` → `wiki_status` → mutating calls) keeps its
+  current mechanics for content — only code-graph tools move to a different server.
+- No secret (`IWIKI_REMOTE_TOKEN`, `IWIKI_LLM_KEY`, etc.) ever lands in a tracked config
+  file when splicing the two JSON configs into one.
+
+## Strategic Context
+- Interacts with: `lib/launcher/launch.sh` (native exec / PII-proxy / combined router
+  branches — the microVM path is already uncovered by `--mcp-config` and stays that way),
+  `.claude_config` / `.claude_config.example`, tracked `mcp/iwiki.json` +
+  `mcp/iwiki-remote.json`, `hooks/iwiki-remote-scope.js`,
+  `tests/test_iwiki_mcp.sh` + `tests/test_iwiki_remote_scope.sh`, the user's global
+  `CLAUDE.md` iwiki Project Binding rule, any skill that references `mcp__iwiki__*` tool
+  names directly.
+- Priority trade-off: **trust** — not breaking today's single-mode (local-only /
+  remote-only) sessions outweighs shipping the dual mode faster.
+
+## Constraints
+### Steering (behavioral guidance)
+- Renaming the server must not change single-mode session behavior (local-only,
+  remote-only) — they see the same server, the same tool names as today, unless their
+  config actually becomes dual.
+- Dual mode is a transparent splice of the two existing JSON configs into one rendered
+  file at launch, not a hand-rewrite of either tracked file.
+- The agent-facing hook instruction must explicitly route: content tools → remote/primary,
+  code-graph tools (`wiki_code_index`/`wiki_code_search`/`wiki_code_context`) → local.
+
+### Hard (architectural enforcement)
+- Secrets (`IWIKI_REMOTE_TOKEN`, `IWIKI_LLM_KEY`, `IWIKI_DB_PASSWORD`, etc.) never land in
+  a tracked git file — only `${VAR}` placeholders, as today.
+- The microVM launch path is not touched (already not covered by `--mcp-config`).
+- No change to the `.iwiki.toml` schema (the `[code_graph]` table stays as-is, per-project).
+
+## Autonomy Zones
+- Full autonomy (reversible, low risk): `lib/iwiki/mcp.sh`, `mcp/iwiki.json`,
+  `mcp/iwiki-remote.json`, `lib/launcher/launch.sh`, `tests/test_iwiki_mcp.sh`,
+  `tests/test_iwiki_remote_scope.sh`, `hooks/iwiki-remote-scope.js`,
+  `docs/iwiki-mcp-modes.md`.
+- Guarded (log + confidence threshold): updates to `.claude_config.example` (variable
+  documentation).
+- Proposal-first (needs approval): any edit to a skill that references `mcp__iwiki__*` by
+  name, if any are found.
+- No autonomy (human only): the user's global `CLAUDE.md` outside this repo — not a
+  project file, never edited by this task.
+
+> These zones OVERRIDE subagent-driven-development's "continuous execution,
+> don't pause" default. Any task touching proposal-first / no-go decisions
+> is marked HUMAN CHECKPOINT in the plan.
+
+## Stop Rules
+- Halt if: renaming the server is found to break a single-mode session (local-only or
+  remote-only).
+- Escalate if: solving this turns out to require changing the `.iwiki.toml` schema.
+- Done when: in a dual session (local + remote both configured), `wiki_code_index`
+  builds the graph without `source_unavailable`, `wiki_code_publish_*` pushes the
+  snapshot to the hosted server in the same session, both existing test files stay
+  green, and single-mode sessions show no regression (verified manually / by test).

--- a/docs/superpowers/reports/iwiki-dual-mcp-registration-results.html
+++ b/docs/superpowers/reports/iwiki-dual-mcp-registration-results.html
@@ -1,0 +1,200 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>iwiki-dual-mcp-registration — отчёт о внедрении</title>
+<style>
+:root{
+  --bg:#f6f7fb; --surface:#ffffff; --fg:#2b2b3a; --muted:#6b6b80;
+  --accent:#5c6bc0; --accent-2:#3949ab; --border:#d6d8e6; --line:#9aa0b4; --zebra:#eef0f8;
+  --ok:#43a047; --ok-2:#2e7d32; --warn:#fb8c00; --warn-2:#ef6c00; --danger:#e53935; --danger-2:#c62828;
+  --shadow:rgba(40,40,80,.18);
+}
+body:has(#theme-toggle:checked){
+  --bg:#181825; --surface:#262637; --fg:#cdd6f4; --muted:#a6adc8;
+  --accent:#89b4fa; --accent-2:#5e95f0; --border:#3a3b52; --line:#6c7086; --zebra:#21222f;
+  --ok:#a6e3a1; --ok-2:#74c46e; --warn:#f9e2af; --warn-2:#f5c95b; --danger:#f38ba8; --danger-2:#e8638a;
+  --shadow:rgba(0,0,0,.45);
+}
+body{
+  margin:0 auto; padding:1.5rem 2rem 4rem; max-width:1080px;
+  font:16px/1.55 system-ui, sans-serif;
+  background:
+    radial-gradient(1200px 500px at 100% -10%, color-mix(in srgb,var(--accent) 10%, transparent), transparent),
+    var(--bg);
+  color:var(--fg);
+  transition:background .3s, color .3s;
+}
+.theme-btn{
+  position:sticky; top:.5rem; float:right;
+  cursor:pointer; user-select:none;
+  padding:.25rem .6rem; border:1px solid var(--border); border-radius:6px;
+  background:var(--surface);
+}
+h1{ font-size:1.6rem; margin-bottom:.2rem; }
+h2{ font-size:1.2rem; margin-top:2.2rem; border-bottom:1px solid var(--border); padding-bottom:.3rem; }
+.lead{ color:var(--muted); margin-top:0; }
+.meta{ display:flex; gap:1.2rem; flex-wrap:wrap; margin:.8rem 0 1.4rem; font-size:.92rem; color:var(--muted); }
+.meta code{ color:var(--fg); }
+code{ background:var(--zebra); padding:.05rem .35rem; border-radius:4px; font-size:.9em; }
+table{ width:100%; border-collapse:collapse; margin:.8rem 0 1.4rem; font-size:.92rem; }
+th,td{ text-align:left; padding:.5rem .6rem; border-bottom:1px solid var(--border); vertical-align:top; }
+th{ color:var(--muted); font-weight:600; }
+tr:nth-child(even) td{ background:var(--zebra); }
+.badge{ display:inline-block; padding:.12rem .55rem; border-radius:999px; font-size:.78rem; font-weight:600; }
+.badge-ok{ background:color-mix(in srgb, var(--ok) 20%, transparent); color:var(--ok-2); }
+.badge-done{ background:color-mix(in srgb, var(--ok) 20%, transparent); color:var(--ok-2); }
+.badge-added{ background:color-mix(in srgb, var(--accent) 20%, transparent); color:var(--accent-2); }
+.badge-modified{ background:color-mix(in srgb, var(--warn) 20%, transparent); color:var(--warn-2); }
+.note{ background:var(--surface); border:1px solid var(--border); border-left:4px solid var(--accent); border-radius:8px; padding:.9rem 1.1rem; margin:1rem 0; box-shadow:0 2px 8px var(--shadow); }
+.note.ok{ border-left-color:var(--ok); }
+figure.diagram{ margin:1.2rem 0; }
+figure.diagram svg{ width:100%; height:auto; display:block; overflow:visible; }
+figcaption{ color:var(--muted); font-size:.85rem; margin-top:.35rem; text-align:center; }
+.card{ fill:var(--surface); stroke:var(--border); stroke-width:1.5; filter:url(#dropshadow); }
+.bar-accent{ fill:var(--accent); } .bar-ok{ fill:var(--ok); } .bar-warn{ fill:var(--warn); } .bar-term{ fill:var(--danger); }
+.t-title{ fill:var(--fg); font:600 14px system-ui, sans-serif; }
+.t-sub{ fill:var(--muted); font:11px system-ui, sans-serif; }
+.t-mono{ font-family:ui-monospace, monospace; }
+text{ pointer-events:none; }
+.conn{ fill:none; stroke:var(--line); stroke-width:2; }
+.conn-a{ fill:none; stroke:var(--accent); stroke-width:2; stroke-dasharray:5 5; }
+.flow{ fill:none; stroke:var(--accent); stroke-width:2.6; stroke-dasharray:8 6; animation:dash 1.1s linear infinite; }
+.flow-ok{ fill:none; stroke:var(--ok); stroke-width:2.6; stroke-dasharray:8 6; animation:dash 1.1s linear infinite; }
+@keyframes dash{ to{ stroke-dashoffset:-14; } }
+@media (prefers-reduced-motion: reduce){ .flow,.flow-ok{ animation:none; } }
+.lbl-bg{ fill:var(--bg); }
+.lbl{ fill:var(--fg); font:11px system-ui, sans-serif; }
+.boundary-rect{ fill:none; stroke:var(--accent); stroke-width:1.6; stroke-dasharray:7 6; opacity:.85; }
+footer{ margin-top:2.5rem; color:var(--muted); font-size:.85rem; text-align:center; }
+</style>
+</head>
+<body>
+<input type="checkbox" id="theme-toggle" hidden>
+<label for="theme-toggle" class="theme-btn" title="Тема">🌙 / ☀️</label>
+
+<svg width="0" height="0" style="position:absolute" aria-hidden="true"><defs>
+  <filter id="dropshadow" x="-20%" y="-20%" width="140%" height="160%">
+    <feDropShadow dx="0" dy="2.5" stdDeviation="3.5" flood-color="var(--shadow)" flood-opacity="1"/>
+  </filter>
+  <marker id="arr"     markerUnits="userSpaceOnUse" markerWidth="12" markerHeight="12" refX="9" refY="4" orient="auto"><path d="M0,0 L9,4 L0,8 Z" fill="var(--line)"/></marker>
+  <marker id="arrA"    markerUnits="userSpaceOnUse" markerWidth="12" markerHeight="12" refX="9" refY="4" orient="auto"><path d="M0,0 L9,4 L0,8 Z" fill="var(--accent)"/></marker>
+  <marker id="arrOk"   markerUnits="userSpaceOnUse" markerWidth="12" markerHeight="12" refX="9" refY="4" orient="auto"><path d="M0,0 L9,4 L0,8 Z" fill="var(--ok)"/></marker>
+</defs></svg>
+
+<main class="report">
+<h1>iwiki-dual-mcp-registration</h1>
+<p class="lead">Отчёт о внедрении — регистрация local + remote iwiki MCP серверов одновременно.</p>
+
+<h2>Резюме внедрения</h2>
+<div class="meta">
+  <span>Intent: <code>docs/superpowers/intents/2026-08-17-iwiki-dual-mcp-registration-intent.md</code> (approved, route <b>execute</b>)</span>
+  <span>Spec: <code>n/a</code></span>
+  <span>Plan: <code>n/a</code></span>
+  <span>Diff base: <code>7096bb7c</code> .. <code>HEAD</code> (branch <code>dev-iwiki-dual-mcp-registration</code>)</span>
+</div>
+<div class="note ok">
+  Проблема: <code>wiki_code_index</code> требует локальный чекаут (падает <code>source_unavailable</code> под remote-only),
+  а <code>wiki_code_publish_*</code> требует hosted-транзит (падает <code>unsupported_storage</code> под local-only).
+  Построить граф локально и опубликовать его — было невозможно в одной сессии из-за эксклюзивного выбора сервера.
+</div>
+
+<h2>Выполненные изменения</h2>
+<table>
+<tr><th>Файл</th><th>Тип</th><th>± строк</th><th>Описание</th></tr>
+<tr><td><code>lib/iwiki/mcp.sh</code></td><td><span class="badge badge-modified">modified</span></td><td>+114/-49</td><td>Новые <code>_iwiki_local_selected</code>, <code>iwiki_mcp_dual_config_file</code>, <code>_iwiki_render_code_graph</code>; <code>iwiki_mcp_enabled</code> = OR local/remote; <code>iwiki_mcp_launch_config</code> выбирает dual, когда оба usable.</td></tr>
+<tr><td><code>mcp/iwiki-dual.json</code></td><td><span class="badge badge-added">added</span></td><td>+38</td><td>Трекнутый secret-free конфиг: два сервера — <code>iwiki-local</code> (stdio) и <code>iwiki-remote</code> (http) в одном файле.</td></tr>
+<tr><td><code>lib/launcher/launch.sh</code></td><td><span class="badge badge-modified">modified</span></td><td>+8/-2</td><td>Обновлён комментарий про 3-way выбор конфига; сама логика вызова уже была общей, без изменений.</td></tr>
+<tr><td><code>hooks/iwiki-remote-scope.js</code></td><td><span class="badge badge-modified">modified</span></td><td>+24/-6</td><td>Детект dual-режима по <code>IWIKI_COMMAND</code>+<code>IWIKI_LLM_KEY</code> рядом с <code>IWIKI_REMOTE_URL</code>; маршрутизация code-graph тулов на <code>iwiki-local</code>, остального — на <code>iwiki-remote</code>.</td></tr>
+<tr><td><code>docs/iwiki-mcp-modes.md</code></td><td><span class="badge badge-modified">modified</span></td><td>+37/-4</td><td>Новая секция «Dual mode» документирует механизм.</td></tr>
+<tr><td><code>tests/test_iwiki_mcp.sh</code></td><td><span class="badge badge-modified">modified</span></td><td>+48/-3</td><td>Переписан «remote wins» сценарий (только когда local не usable); добавлено 5 dual-ассертов.</td></tr>
+<tr><td><code>tests/test_iwiki_remote_scope.sh</code></td><td><span class="badge badge-modified">modified</span></td><td>+36</td><td>Добавлены проверки remote-only code-graph note и dual routing note.</td></tr>
+<tr><td><code>docs/superpowers/intents/2026-08-17-iwiki-dual-mcp-registration-intent.md</code></td><td><span class="badge badge-added">added</span></td><td>+100</td><td>Intent-документ (approved, chain review OK, result reconciliation OK).</td></tr>
+</table>
+
+<h2>Результаты</h2>
+<table>
+<tr><th>Desired Outcome</th><th>Статус</th><th>Свидетельство</th></tr>
+<tr><td>Dual-сессия: <code>wiki_code_index</code> больше не <code>source_unavailable</code></td><td><span class="badge badge-done">DONE</span></td><td><code>iwiki-local</code> сервер зарегистрирован с доступом к чекауту</td></tr>
+<tr><td>Dual-сессия: <code>wiki_code_publish_*</code> успешно пушит снапшот</td><td><span class="badge badge-done">DONE</span></td><td><code>iwiki-remote</code> сорегистрирован, hosted-транзит не тронут</td></tr>
+<tr><td>Content-тулы продолжают идти через remote/primary, без регресса</td><td><span class="badge badge-done">DONE</span></td><td>single-mode файлы не тронуты; hook явно маршрутизирует не-code-graph тулы на <code>iwiki-remote</code></td></tr>
+<tr><td>local-only / remote-only сессии не меняются</td><td><span class="badge badge-done">DONE</span></td><td><code>tests/test_iwiki_mcp.sh</code> 30/30, <code>tests/test_iwiki_remote_scope.sh</code> 10/10, имя сервера <code>iwiki</code> побайтово прежнее</td></tr>
+</table>
+<p><b>Покрытие Desired Outcomes: 4/4.</b> Spec: n/a (execute-route). Plan: n/a (execute-route). Excess-изменений нет — каждый изменённый файл соответствует Desired Outcome или Hard/Steering ограничению.</p>
+<p><b>Итоговый вердикт: OK.</b></p>
+
+<h2>Влияние на систему</h2>
+<table>
+<tr><th>Компонент</th><th>Изменение</th><th>Риск / follow-up</th></tr>
+<tr><td><code>lib/iwiki/mcp.sh</code></td><td>Новая dual-ветка выбора конфига</td><td>Покрыто тестами; риск низкий</td></tr>
+<tr><td><code>mcp/iwiki-dual.json</code></td><td>Новый трекнутый файл, только <code>${VAR}</code> плейсхолдеры</td><td>Секретов нет, проверено</td></tr>
+<tr><td><code>hooks/iwiki-remote-scope.js</code></td><td>Новая ветка инструкции агенту для dual-режима</td><td>Покрыто тестами</td></tr>
+<tr><td>Skills, ссылающиеся на <code>mcp__iwiki__*</code></td><td>Поиск (grep) — не найдено ни одного</td><td>Proposal-first зона intent не потребовалась</td></tr>
+<tr><td>Глобальный пользовательский <code>CLAUDE.md</code></td><td>Не тронут</td><td>No-autonomy зона, вне скоупа задачи</td></tr>
+</table>
+
+<h2>Схемы</h2>
+
+<figure class="diagram">
+<svg viewBox="0 0 920 260" role="img" aria-label="Решающий граф iwiki_mcp_launch_config">
+  <g class="node"><rect class="card" x="20" y="100" width="170" height="60" rx="12"/><rect class="bar-accent" x="28" y="112" width="5" height="36" rx="2.5"/><text class="t-title" x="105" y="126" text-anchor="middle">local usable?</text><text class="t-sub" x="105" y="144" text-anchor="middle">_iwiki_local_selected</text></g>
+
+  <g class="node"><rect class="card" x="330" y="20" width="200" height="60" rx="12"/><rect class="bar-ok" x="338" y="32" width="5" height="36" rx="2.5"/><text class="t-title" x="430" y="46" text-anchor="middle">dual + remote usable?</text><text class="t-sub" x="430" y="64" text-anchor="middle">iwiki-dual.json exists</text></g>
+
+  <g class="node"><rect class="card" x="650" y="20" width="230" height="60" rx="12"/><rect class="bar-accent" x="658" y="32" width="5" height="36" rx="2.5"/><text class="t-title t-mono" x="765" y="46" text-anchor="middle">mcp/iwiki-dual.json</text><text class="t-sub" x="765" y="64" text-anchor="middle">iwiki-local + iwiki-remote</text></g>
+
+  <g class="node"><rect class="card" x="330" y="180" width="200" height="60" rx="12"/><rect class="bar-warn" x="338" y="192" width="5" height="36" rx="2.5"/><text class="t-title" x="430" y="196" text-anchor="middle">remote usable?</text><text class="t-sub" x="430" y="224" text-anchor="middle">_iwiki_remote_selected</text></g>
+
+  <g class="node"><rect class="card" x="650" y="180" width="230" height="60" rx="12"/><rect class="bar-warn" x="658" y="192" width="5" height="36" rx="2.5"/><text class="t-title t-mono" x="765" y="196" text-anchor="middle">mcp/iwiki-remote.json</text><text class="t-sub" x="765" y="224" text-anchor="middle">server name "iwiki"</text></g>
+
+  <g class="node"><rect class="card" x="20" y="180" width="230" height="60" rx="12"/><rect class="bar-ok" x="28" y="192" width="5" height="36" rx="2.5"/><text class="t-title t-mono" x="135" y="196" text-anchor="middle">mcp/iwiki.json</text><text class="t-sub" x="135" y="224" text-anchor="middle">server name "iwiki" (local-only)</text></g>
+
+  <path class="flow" marker-end="url(#arrA)" d="M190,120 C260,120 260,50 327,50"/>
+  <rect class="lbl-bg" x="200" y="70" width="30" height="16"/><text class="lbl" x="215" y="82" text-anchor="middle">да</text>
+
+  <path class="flow-ok" marker-end="url(#arrOk)" d="M530,50 H647"/>
+  <rect class="lbl-bg" x="555" y="34" width="30" height="16"/><text class="lbl" x="570" y="46" text-anchor="middle">да</text>
+
+  <path class="conn-a" marker-end="url(#arrA)" d="M430,80 V177"/>
+  <rect class="lbl-bg" x="440" y="120" width="34" height="16"/><text class="lbl" x="457" y="132" text-anchor="middle">нет</text>
+
+  <path class="flow" marker-end="url(#arrA)" d="M530,210 H647"/>
+  <rect class="lbl-bg" x="555" y="194" width="30" height="16"/><text class="lbl" x="570" y="206" text-anchor="middle">да</text>
+
+  <path class="conn-a" marker-end="url(#arrA)" d="M105,160 V180"/>
+  <path class="conn-a" marker-end="url(#arrA)" d="M330,210 H250"/>
+  <rect class="lbl-bg" x="255" y="192" width="34" height="16"/><text class="lbl" x="272" y="204" text-anchor="middle">нет</text>
+</svg>
+<figcaption>local не usable → нет dual-ветки; remote решает по своему usability (иначе — local-only файл).</figcaption>
+</figure>
+
+<figure class="diagram">
+<svg viewBox="0 0 920 260" role="img" aria-label="Архитектура dual-режима">
+  <rect class="boundary-rect" x="20" y="20" width="880" height="220" rx="16"/>
+  <rect class="lbl-bg" x="34" y="12" width="260" height="18"/>
+  <text class="lbl" x="42" y="25" font-weight="600">Одна Claude Code сессия, --mcp-config = mcp/iwiki-dual.json</text>
+
+  <g class="node"><rect class="card" x="60" y="100" width="190" height="60" rx="12"/><rect class="bar-accent" x="68" y="112" width="5" height="36" rx="2.5"/><text class="t-title" x="155" y="126" text-anchor="middle">launch.sh</text><text class="t-sub" x="155" y="144" text-anchor="middle">--mcp-config</text></g>
+
+  <g class="node"><rect class="card" x="380" y="50" width="200" height="60" rx="12"/><rect class="bar-ok" x="388" y="62" width="5" height="36" rx="2.5"/><text class="t-title t-mono" x="480" y="76" text-anchor="middle">iwiki-local</text><text class="t-sub" x="480" y="94" text-anchor="middle">stdio · project checkout</text></g>
+
+  <g class="node"><rect class="card" x="380" y="150" width="200" height="60" rx="12"/><rect class="bar-warn" x="388" y="162" width="5" height="36" rx="2.5"/><text class="t-title t-mono" x="480" y="176" text-anchor="middle">iwiki-remote</text><text class="t-sub" x="480" y="194" text-anchor="middle">http · hosted PostgreSQL</text></g>
+
+  <g class="node"><rect class="card" x="680" y="50" width="200" height="60" rx="12"/><rect class="bar-ok" x="688" y="62" width="5" height="36" rx="2.5"/><text class="t-title t-mono" x="780" y="76" text-anchor="middle">wiki_code_index</text><text class="t-sub" x="780" y="94" text-anchor="middle">_search / _context</text></g>
+
+  <g class="node"><rect class="card" x="680" y="150" width="200" height="60" rx="12"/><rect class="bar-warn" x="688" y="162" width="5" height="36" rx="2.5"/><text class="t-title t-mono" x="780" y="176" text-anchor="middle">wiki_code_publish_*</text><text class="t-sub" x="780" y="194" text-anchor="middle">+ every other wiki_* tool</text></g>
+
+  <path class="flow" marker-end="url(#arrA)" d="M250,120 C300,120 320,80 377,80"/>
+  <path class="flow" marker-end="url(#arrA)" d="M250,140 C300,140 320,180 377,180"/>
+  <path class="flow-ok" marker-end="url(#arrOk)" d="M580,80 H677"/>
+  <path class="flow" marker-end="url(#arrA)" d="M580,180 H677"/>
+</svg>
+<figcaption>Одна сессия одновременно видит оба транспорта: код-граф строится локально, публикуется на hosted.</figcaption>
+</figure>
+
+</main>
+
+<footer>Сгенерировано check-chain / html-report · iwiki-dual-mcp-registration · branch dev-iwiki-dual-mcp-registration</footer>
+</body>
+</html>

--- a/lib/iwiki/mcp.sh
+++ b/lib/iwiki/mcp.sh
@@ -4,12 +4,17 @@
 # iwiki MCP Registration Helper
 # Description: Decides whether an iwiki MCP server is handed to Claude Code via
 #              --mcp-config, and which tracked, secret-free config describes it:
-#              mcp/iwiki-remote.json for a hosted Streamable HTTP server, or
+#              mcp/iwiki-remote.json for a hosted Streamable HTTP server,
 #              mcp/iwiki.json for the local stdio server (optionally rendered
-#              with the code-graph overrides). The IWIKI_* values are already
-#              exported by lib/config/env-map.sh (de-prefixed from
-#              ICLAUDE_IWIKI_* in .claude_config); this module only resolves the
-#              binary path, evaluates the enable gate, and picks the config.
+#              with the code-graph overrides), or mcp/iwiki-dual.json when both
+#              are usable at once — registered as two distinct servers,
+#              "iwiki-local" and "iwiki-remote", so wiki_code_index/_search/
+#              _context can run locally while every other wiki_* tool and
+#              wiki_code_publish_* still reach the hosted server in the same
+#              session. The IWIKI_* values are already exported by
+#              lib/config/env-map.sh (de-prefixed from ICLAUDE_IWIKI_* in
+#              .claude_config); this module only resolves the binary path,
+#              evaluates the enable gate, and picks the config.
 #######################################
 
 # Absolute path to the tracked, secret-free MCP config file.
@@ -30,14 +35,34 @@ iwiki_mcp_remote_config_file() {
     printf '%s' "${CLAUDE_CONFIG_DIR:-${ISOLATED_CONFIG_DIR:-}}/mcp/iwiki-remote.json"
 }
 
+# Absolute path to the tracked config that registers both transports at once,
+# as "iwiki-local" and "iwiki-remote". Used only when both modes are usable;
+# a single distinct file keeps single-mode registration (server name "iwiki")
+# byte-identical to today.
+iwiki_mcp_dual_config_file() {
+    printf '%s' "${CLAUDE_CONFIG_DIR:-${ISOLATED_CONFIG_DIR:-}}/mcp/iwiki-dual.json"
+}
+
 # True when remote mode is both requested and usable: an explicit URL, a token
 # to authenticate with, and the tracked remote config present. Setting the URL
-# is the deliberate opt-in, so remote wins over a local install when both are
-# configured.
+# is the deliberate opt-in, so remote wins over a local install when local is
+# not ALSO usable (see iwiki_mcp_launch_config for the dual case).
 _iwiki_remote_selected() {
     [[ -n "${IWIKI_REMOTE_URL:-}" ]]                 || return 1
     [[ -n "${IWIKI_REMOTE_TOKEN:-}" ]]               || return 1
     [[ -f "$(iwiki_mcp_remote_config_file)" ]]       || return 1
+    return 0
+}
+
+# True when local (stdio) mode is usable on its own: the binary resolves, the
+# embeddings key is configured, and the tracked local config exists. Factored
+# out of iwiki_mcp_enabled so dual-mode registration can check it independently
+# of whether remote also wins the single-mode selection.
+_iwiki_local_selected() {
+    iwiki_resolve_command
+    [[ -n "${IWIKI_COMMAND:-}" ]]            || return 1
+    [[ -n "${IWIKI_LLM_KEY:-}" ]]            || return 1
+    [[ -f "$(iwiki_mcp_config_file)" ]]      || return 1
     return 0
 }
 
@@ -56,19 +81,13 @@ iwiki_resolve_command() {
 }
 
 # Return 0 (enabled) when the iwiki MCP server should be registered, in either
-# of two modes. Remote mode needs only a URL, a token, and the tracked remote
-# config. Local (stdio) mode needs:
-#   - the binary resolved (IWIKI_COMMAND non-empty), AND
-#   - iwiki is configured (IWIKI_LLM_KEY non-empty), AND
-#   - the tracked config file exists.
-# Returns 1 otherwise, so launch proceeds without the server (no hard failure).
+# of two modes (see _iwiki_local_selected / _iwiki_remote_selected for the
+# exact conditions of each). Returns 1 when neither is usable, so launch
+# proceeds without the server (no hard failure).
 iwiki_mcp_enabled() {
+    _iwiki_local_selected && return 0
     _iwiki_remote_selected && return 0
-    iwiki_resolve_command
-    [[ -n "${IWIKI_COMMAND:-}" ]]            || return 1
-    [[ -n "${IWIKI_LLM_KEY:-}" ]]            || return 1
-    [[ -f "$(iwiki_mcp_config_file)" ]]      || return 1
-    return 0
+    return 1
 }
 
 # Code-graph variables the iwiki-mcp server reads. They are NOT part of the
@@ -94,25 +113,15 @@ _iwiki_code_graph_env_lines() {
     return 0
 }
 
-# Print the config path to hand to `--mcp-config`.
-# In remote mode this is the tracked remote config; the code-graph render does
-# not apply, because a hosted server owns its own storage and code-graph cache.
-# In local mode, without configured code-graph vars this is the tracked file
-# itself, and any render left over from an earlier launch is removed so a stale
-# file can never be mistaken for the active config. With them, a sibling
-# *.runtime.json is rendered by splicing the extra keys into the `env` object; it
-# holds only `${VAR}` placeholders, so it stays secret-free like the tracked
-# original (it is git-ignored because it is machine-specific). A write failure,
-# or a tracked file with no `env` object to splice into, falls back to the
-# tracked file — iwiki still starts, only without the code-graph overrides.
-iwiki_mcp_launch_config() {
-    local tracked lines runtime
-    if _iwiki_remote_selected; then
-        iwiki_mcp_remote_config_file
-        return 0
-    fi
-    tracked="$(iwiki_mcp_config_file)"
-    runtime="${tracked%.json}.runtime.json"
+# Render $1 (a tracked config with exactly one "env" object, the local
+# server's) into $2 (its *.runtime.json sibling), splicing configured
+# code-graph vars into that env object. Prints $2 on a successful render, or
+# $1 unchanged when no vars are configured or the splice fails (no `env`
+# object to splice into) — iwiki still starts, only without the code-graph
+# overrides. Always leaves at most one of the two present on disk, so a stale
+# render from an earlier launch is never mistaken for the active config.
+_iwiki_render_code_graph() {
+    local tracked="$1" runtime="$2" lines
     lines="$(_iwiki_code_graph_env_lines)"
     if [[ -z "$lines" ]]; then
         rm -f "$runtime" 2>/dev/null || true
@@ -129,4 +138,35 @@ iwiki_mcp_launch_config() {
         rm -f "$runtime" 2>/dev/null || true
         printf '%s' "$tracked"
     fi
+}
+
+# Print the config path to hand to `--mcp-config`.
+# Dual mode (both local and remote usable, and mcp/iwiki-dual.json present)
+# registers both transports at once under distinct names, "iwiki-local" and
+# "iwiki-remote", so wiki_code_index/_search/_context can run locally while
+# wiki_code_publish_* and every other wiki_* tool still reach the hosted
+# server. Otherwise remote wins when usable (the deliberate opt-in), else
+# local. In remote-only mode the code-graph render does not apply, because a
+# hosted server owns its own storage and code-graph cache; local-only and dual
+# mode both render code-graph overrides into the local server's `env` object
+# via _iwiki_render_code_graph (the dual tracked file's remote entry has no
+# `env` key, so the splice only ever touches the local one).
+iwiki_mcp_launch_config() {
+    local tracked runtime
+
+    if _iwiki_local_selected && _iwiki_remote_selected && [[ -f "$(iwiki_mcp_dual_config_file)" ]]; then
+        tracked="$(iwiki_mcp_dual_config_file)"
+        runtime="${tracked%.json}.runtime.json"
+        _iwiki_render_code_graph "$tracked" "$runtime"
+        return 0
+    fi
+
+    if _iwiki_remote_selected; then
+        iwiki_mcp_remote_config_file
+        return 0
+    fi
+
+    tracked="$(iwiki_mcp_config_file)"
+    runtime="${tracked%.json}.runtime.json"
+    _iwiki_render_code_graph "$tracked" "$runtime"
 }

--- a/lib/launcher/launch.sh
+++ b/lib/launcher/launch.sh
@@ -823,13 +823,15 @@ launch_claude() {
     local -a claude_cmd_arr
     read -ra claude_cmd_arr <<< "$claude_cmd"
 
-    # Register the iwiki MCP server from the tracked, secret-free mcp/iwiki.json
+    # Register the iwiki MCP server(s) from the tracked, secret-free mcp/iwiki*.json
     # when configured. iwiki_mcp_enabled resolves + exports IWIKI_COMMAND so
     # Claude Code can expand ${IWIKI_COMMAND}/${IWIKI_*} at spawn time. The flag
     # is added to claude_cmd_arr, so it flows into every launch branch below.
     # (The microVM path execs earlier and is intentionally not covered.)
-    # iwiki_mcp_launch_config returns the tracked file, or a rendered sibling when
-    # the optional IWIKI_CODE_GRAPH_* vars are configured (see lib/iwiki/mcp.sh).
+    # iwiki_mcp_launch_config returns the tracked local or remote file (or a
+    # rendered sibling when the optional IWIKI_CODE_GRAPH_* vars are configured),
+    # or the dual-mode tracked file registering both "iwiki-local" and
+    # "iwiki-remote" when both transports are usable (see lib/iwiki/mcp.sh).
     if declare -f iwiki_mcp_enabled >/dev/null 2>&1 && iwiki_mcp_enabled; then
         claude_cmd_arr+=( --mcp-config "$(iwiki_mcp_launch_config)" )
     fi

--- a/tests/test_iwiki_mcp.sh
+++ b/tests/test_iwiki_mcp.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # Unit tests for lib/iwiki/mcp.sh:
-#   iwiki_mcp_config_file, iwiki_resolve_command, iwiki_mcp_enabled.
+#   iwiki_mcp_config_file, iwiki_resolve_command, iwiki_mcp_enabled,
+#   iwiki_mcp_launch_config (single local, single remote, and dual mode).
 set -uo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 source "$ROOT/lib/iwiki/mcp.sh"
@@ -102,18 +103,55 @@ assert_eq "$(PATH="/nonexistent"; CLAUDE_CONFIG_DIR="$TD/.claude-isolated"; unse
 assert_eq "$(PATH="/nonexistent"; CLAUDE_CONFIG_DIR="$TD/.claude-isolated"; unset IWIKI_LLM_KEY IWIKI_COMMAND IWIKI_REMOTE_TOKEN; IWIKI_REMOTE_URL=https://w.example/mcp; iwiki_mcp_enabled && echo YES || echo NO)" \
   "NO" "remote: disabled without a token"
 
-# Remote is the deliberate opt-in, so it wins over a usable local install.
-assert_eq "$(PATH="$TD/bin:$PATH"; CLAUDE_CONFIG_DIR="$TD/.claude-isolated"; IWIKI_LLM_KEY=sk-x; unset IWIKI_COMMAND; IWIKI_REMOTE_URL=https://w.example/mcp; IWIKI_REMOTE_TOKEN=t; iwiki_mcp_launch_config)" \
-  "$RCFG" "remote: selected over the local config"
+# Remote is the deliberate opt-in, so it wins when local is NOT also usable
+# (no binary here: IWIKI_COMMAND stays unset and PATH offers no iwiki-mcp).
+assert_eq "$(PATH="/nonexistent"; CLAUDE_CONFIG_DIR="$TD/.claude-isolated"; unset IWIKI_LLM_KEY IWIKI_COMMAND; IWIKI_REMOTE_URL=https://w.example/mcp; IWIKI_REMOTE_TOKEN=t; iwiki_mcp_launch_config)" \
+  "$RCFG" "remote: selected when local is not usable"
 
 # Remote never renders the code-graph sibling: a hosted server owns that cache.
-assert_eq "$(CLAUDE_CONFIG_DIR="$TD/.claude-isolated"; IWIKI_REMOTE_URL=https://w.example/mcp; IWIKI_REMOTE_TOKEN=t; IWIKI_CODE_GRAPH_ENABLED=true; iwiki_mcp_launch_config)" \
+assert_eq "$(PATH="/nonexistent"; CLAUDE_CONFIG_DIR="$TD/.claude-isolated"; unset IWIKI_LLM_KEY IWIKI_COMMAND; IWIKI_REMOTE_URL=https://w.example/mcp; IWIKI_REMOTE_TOKEN=t; IWIKI_CODE_GRAPH_ENABLED=true; iwiki_mcp_launch_config)" \
   "$RCFG" "remote: no code-graph render"
 
 # Without the tracked remote config, remote cannot be selected.
 rm -f "$RCFG"
 assert_eq "$(CLAUDE_CONFIG_DIR="$TD/.claude-isolated"; unset "${_IWIKI_CODE_GRAPH_VARS[@]}"; IWIKI_REMOTE_URL=https://w.example/mcp; IWIKI_REMOTE_TOKEN=t; iwiki_mcp_launch_config)" \
   "$CFG" "remote: falls back to local without the remote config"
+
+# ---------------------------------------------------------------------------
+# Dual mode: both local and remote usable -> register both as distinct servers.
+# ---------------------------------------------------------------------------
+# The single-mode remote config keeps its key "iwiki" (existence is all that
+# matters to _iwiki_remote_selected/dual's fallback check below); only the
+# dual tracked file uses the distinct "iwiki-local"/"iwiki-remote" names.
+printf '%s' '{"mcpServers":{"iwiki":{"type":"http","url":"${IWIKI_REMOTE_URL}"}}}' > "$RCFG"
+DCFG="$TD/.claude-isolated/mcp/iwiki-dual.json"
+printf '%s\n' '{' '  "mcpServers": {' '    "iwiki-local": {' '      "env": {' \
+  '        "IWIKI_TOP_K": "${IWIKI_TOP_K:-8}"' '      }' '    },' \
+  '    "iwiki-remote": {' '      "url": "${IWIKI_REMOTE_URL}"' '    }' '  }' '}' > "$DCFG"
+
+# Both configured, dual tracked file present: enabled, and the dual file wins
+# over either single config.
+assert_eq "$(PATH="$TD/bin:$PATH"; CLAUDE_CONFIG_DIR="$TD/.claude-isolated"; IWIKI_LLM_KEY=sk-x; unset IWIKI_COMMAND; IWIKI_REMOTE_URL=https://w.example/mcp; IWIKI_REMOTE_TOKEN=t; iwiki_mcp_enabled && echo YES || echo NO)" \
+  "YES" "dual: enabled when both are usable"
+assert_eq "$(PATH="$TD/bin:$PATH"; CLAUDE_CONFIG_DIR="$TD/.claude-isolated"; IWIKI_LLM_KEY=sk-x; unset IWIKI_COMMAND; IWIKI_REMOTE_URL=https://w.example/mcp; IWIKI_REMOTE_TOKEN=t; unset "${_IWIKI_CODE_GRAPH_VARS[@]}"; iwiki_mcp_launch_config)" \
+  "$DCFG" "dual: selected over either single config"
+
+# Dual code-graph render: splices only into the local entry's "env" object,
+# not the remote entry (which has none).
+RENDERED_D="$(PATH="$TD/bin:$PATH"; CLAUDE_CONFIG_DIR="$TD/.claude-isolated"; IWIKI_LLM_KEY=sk-x; unset IWIKI_COMMAND; IWIKI_REMOTE_URL=https://w.example/mcp; IWIKI_REMOTE_TOKEN=t; IWIKI_CODE_GRAPH_ENABLED=false; iwiki_mcp_launch_config)"
+assert_eq "$RENDERED_D" "${DCFG%.json}.runtime.json" "dual: renders a runtime file"
+assert_eq "$(python3 -c 'import json,sys; d=json.load(open(sys.argv[1]))["mcpServers"]; print(",".join(sorted(d)))' "$RENDERED_D")" \
+  "iwiki-local,iwiki-remote" "dual: both server names present"
+assert_eq "$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["mcpServers"]["iwiki-local"]["env"]["IWIKI_CODE_GRAPH_ENABLED"])' "$RENDERED_D")" \
+  '${IWIKI_CODE_GRAPH_ENABLED}' "dual: code-graph placeholder spliced into iwiki-local only"
+assert_eq "$(python3 -c 'import json,sys; print("IWIKI_CODE_GRAPH_ENABLED" in json.load(open(sys.argv[1]))["mcpServers"]["iwiki-remote"])' "$RENDERED_D")" \
+  "False" "dual: no code-graph key on iwiki-remote"
+
+# Without the tracked dual config, remote (the deliberate opt-in) is selected
+# as a single server instead — no dual registration is attempted.
+rm -f "$DCFG" "${DCFG%.json}.runtime.json"
+assert_eq "$(PATH="$TD/bin:$PATH"; CLAUDE_CONFIG_DIR="$TD/.claude-isolated"; IWIKI_LLM_KEY=sk-x; unset IWIKI_COMMAND; IWIKI_REMOTE_URL=https://w.example/mcp; IWIKI_REMOTE_TOKEN=t; unset "${_IWIKI_CODE_GRAPH_VARS[@]}"; iwiki_mcp_launch_config)" \
+  "$RCFG" "dual: falls back to remote without the dual config"
 
 rm -rf "$TD"
 echo "iwiki-mcp: PASS=$PASS FAIL=$FAIL"

--- a/tests/test_iwiki_remote_scope.sh
+++ b/tests/test_iwiki_remote_scope.sh
@@ -54,6 +54,42 @@ t_remote_region() {
 }
 t_remote_region
 
+# ---- remote-only: code-graph note tells the agent to switch/add config ----
+t_remote_only_code_graph_note() {
+  echo "[remote-only] no local vars -> code-graph note says switch/add config"
+  local out
+  out="$(env -u IWIKI_COMMAND -u IWIKI_LLM_KEY IWIKI_REMOTE_URL="https://iwiki.example.com/mcp" node "$HOOK")"
+  if [[ "$out" == *"wiki_code_index"* && "$out" == *"source_unavailable"* && "$out" == *"mcp/iwiki.json"* ]]; then
+    pass "notes wiki_code_index needs a local config, not a .iwiki.toml edit"
+  else
+    fail "notes wiki_code_index needs a local config, not a .iwiki.toml edit"
+  fi
+  if [[ "$out" == *"iwiki-local"* && "$out" == *"iwiki-remote"* ]]; then
+    fail "does not claim dual registration when local is not usable"
+  else
+    pass "does not claim dual registration when local is not usable"
+  fi
+}
+t_remote_only_code_graph_note
+
+# ---- dual: local vars also present -> note routes tools per server, no switch ----
+t_dual_code_graph_note() {
+  echo "[dual] IWIKI_COMMAND + IWIKI_LLM_KEY also set -> per-server routing note"
+  local out
+  out="$(IWIKI_REMOTE_URL="https://iwiki.example.com/mcp" IWIKI_COMMAND="/usr/local/bin/iwiki-mcp" IWIKI_LLM_KEY="sk-x" node "$HOOK")"
+  if [[ "$out" == *"iwiki-local"* && "$out" == *"iwiki-remote"* ]]; then
+    pass "routes code-graph tools to iwiki-local, rest to iwiki-remote"
+  else
+    fail "routes code-graph tools to iwiki-local, rest to iwiki-remote"
+  fi
+  if [[ "$out" == *"No config switch is needed"* ]]; then
+    pass "tells the agent no config switch is needed in dual mode"
+  else
+    fail "tells the agent no config switch is needed in dual mode"
+  fi
+}
+t_dual_code_graph_note
+
 # ---- remote output never contains the URL/token themselves ----
 t_remote_no_secrets() {
   echo "[remote] emitted region carries no URL or token"


### PR DESCRIPTION
## Summary
- wiki_code_index needs a local checkout (source_unavailable under remote-only); wiki_code_publish_* needs a hosted transit (unsupported_storage under local-only). Building a code graph and publishing it were mutually exclusive in one session.
- lib/iwiki/mcp.sh now registers mcp/iwiki-dual.json — two distinct servers "iwiki-local" and "iwiki-remote" — whenever both transports are usable, instead of picking one exclusively.
- Single-mode sessions (local-only or remote-only) are unaffected: they keep the plain server name "iwiki" from their existing tracked config, byte for byte.
- hooks/iwiki-remote-scope.js routes the agent accordingly at session start (code-graph tools -> iwiki-local, everything else -> iwiki-remote), and still tells the agent to switch/add the local config under remote-only mode.
- Chain workflow: intent approved (docs/superpowers/intents/2026-08-17-iwiki-dual-mcp-registration-intent.md, execute route) -> implementation -> /check-chain result OK (4/4 Desired Outcomes DONE). HTML report at docs/superpowers/reports/iwiki-dual-mcp-registration-results.html.

## Test plan
- [x] bash tests/test_iwiki_mcp.sh (30/30 pass)
- [x] bash tests/test_iwiki_remote_scope.sh (10/10 pass)