### PR TITLE
chore(toolchain): bump claude-code to 2.1.234

### DIFF
--- a/.nvm-isolated-lockfile.json
+++ b/.nvm-isolated-lockfile.json
@@ -1,6 +1,6 @@
 {
   "nodeVersion": "22.23.1",
-  "claudeCodeVersion": "2.1.233",
+  "claudeCodeVersion": "2.1.234",
   "routerVersion": "unknown",
   "lspServers": {
     "pyright": "1.1.408",
@@ -18,6 +18,6 @@
   "ohMyPoshVersion": "not installed",
   "ohMyPoshPlatform": "unknown",
   "ohMyPoshInstalledAt": "",
-  "installedAt": "2026-08-17T07:08:50Z",
+  "installedAt": "2026-08-18T04:12:55Z",
   "nvmVersion": "0.39.7"
 }

--- a/.nvm-isolated/npm-global/lib/node_modules/@anthropic-ai/claude-code/package.json
+++ b/.nvm-isolated/npm-global/lib/node_modules/@anthropic-ai/claude-code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anthropic-ai/claude-code",
-  "version": "2.1.233",
+  "version": "2.1.234",
   "bin": {
     "claude": "bin/claude.exe"
   },
@@ -21,14 +21,14 @@
   },
   "dependencies": {},
   "optionalDependencies": {
-    "@anthropic-ai/claude-code-darwin-arm64": "2.1.233",
-    "@anthropic-ai/claude-code-darwin-x64": "2.1.233",
-    "@anthropic-ai/claude-code-linux-x64": "2.1.233",
-    "@anthropic-ai/claude-code-linux-arm64": "2.1.233",
-    "@anthropic-ai/claude-code-linux-x64-musl": "2.1.233",
-    "@anthropic-ai/claude-code-linux-arm64-musl": "2.1.233",
-    "@anthropic-ai/claude-code-win32-x64": "2.1.233",
-    "@anthropic-ai/claude-code-win32-arm64": "2.1.233"
+    "@anthropic-ai/claude-code-darwin-arm64": "2.1.234",
+    "@anthropic-ai/claude-code-darwin-x64": "2.1.234",
+    "@anthropic-ai/claude-code-linux-x64": "2.1.234",
+    "@anthropic-ai/claude-code-linux-arm64": "2.1.234",
+    "@anthropic-ai/claude-code-linux-x64-musl": "2.1.234",
+    "@anthropic-ai/claude-code-linux-arm64-musl": "2.1.234",
+    "@anthropic-ai/claude-code-win32-x64": "2.1.234",
+    "@anthropic-ai/claude-code-win32-arm64": "2.1.234"
   },
   "files": [
     "bin/claude.exe",

--- a/.nvm-isolated/npm-global/lib/node_modules/@anthropic-ai/claude-code/sdk-tools.d.ts
+++ b/.nvm-isolated/npm-global/lib/node_modules/@anthropic-ai/claude-code/sdk-tools.d.ts
@@ -424,6 +424,54 @@ export type ArtifactOutput =
       }[];
       truncated?: boolean;
       scope?: "shared" | "all";
+    }
+  | {
+      asset_upload: {
+        id: string;
+        url: string;
+        size_bytes: number;
+        content_type: string;
+        sha256?: string;
+        file_name: string;
+      };
+    }
+  | {
+      asset_list: {
+        url: string;
+        /**
+         * @maxItems 1000
+         */
+        assets: {
+          id: string;
+          url: string;
+          content_type: string;
+          size_bytes: number;
+          sha256?: string;
+          created_at: string;
+        }[];
+        usage: {
+          files: number;
+          bytes: number;
+          max_files: number;
+          max_bytes: number;
+        };
+        next?: string;
+      };
+    }
+  | {
+      asset_read: {
+        id: string;
+        path: string;
+        size_bytes: number;
+        content_type: string;
+        sha256: string;
+      };
+    }
+  | {
+      asset_delete: {
+        id: string;
+        deleted: boolean;
+      };
     };
 export type ProjectsOutput =
   | {
@@ -2878,11 +2926,11 @@ export interface ProposeGoalInput {
 }
 export interface ArtifactInput {
   /**
-   * Omit (or 'publish') to publish file_path. 'list' enumerates artifacts — the user's own by default, see `scope`; only `limit` and `scope` may accompany it.
+   * Omit (or 'publish') to publish file_path. 'list' enumerates artifacts — the user's own by default, see `scope`; only `limit` and `scope` may accompany it. 'upload_asset' adds one local media, PDF, or font file to an existing artifact — pass `url` and `file_path`. 'list_assets' lists the files in an artifact's asset store (pass `url`; `after` continues a listing), 'read_asset' saves one of them to a local file named by its id (pass `url` and `asset_id`, optionally `out_dir`), and 'delete_asset' permanently removes one (pass `url` and `asset_id`). See **Artifact assets** above.
    */
-  action?: "publish" | "list";
+  action?: "publish" | "list" | "upload_asset" | "list_assets" | "read_asset" | "delete_asset";
   /**
-   * Path to an .html or .md file to render. Required to publish (the default action). Use a short, distinctive basename — it is the last-resort title when the HTML has no <title> and no `title` parameter is given.
+   * Path to an .html or .md file to render. Required to publish (the default action). Use a short, distinctive basename — it is the last-resort title when the HTML has no <title> and no `title` parameter is given. For 'upload_asset', the local image, video, PDF, or font file to upload.
    */
   file_path?: string;
   /**
@@ -2917,6 +2965,18 @@ export interface ArtifactInput {
    * Last-resort overwrite that DISCARDS another session's published version. On a 409 conflict the normal fix is to re-read the artifact, merge your edits on top of the newer content, and publish again — not force. Pass force:true only when the user explicitly wants to replace the other session's version. The tracked baseVersion is still sent; with force:true the server treats it as informational and overwrites. Omit (or false) so a concurrent write 409s instead of being silently clobbered.
    */
   force?: boolean;
+  /**
+   * read_asset and delete_asset: the asset's id (32 hex characters), from a list_assets or upload_asset result.
+   */
+  asset_id?: string;
+  /**
+   * read_asset only: directory to save the file into (default: the working directory). The file is named by the asset id plus the extension for its type.
+   */
+  out_dir?: string;
+  /**
+   * list_assets only: the `next` value from a previous list_assets result, to continue that listing.
+   */
+  after?: string;
 }
 export interface PushNotificationInput {
   /**
@@ -3043,6 +3103,7 @@ export interface BashOutput {
         | "merged"
         | "commented"
         | "closed"
+        | "reopened"
         | "ready"
         | "draft"
         | "auto-merge-enabled"
@@ -3803,6 +3864,10 @@ export interface REPLOutput {
    * Error message if execution failed
    */
   error?: string;
+  /**
+   * True on an async-dispatch receipt or refusal: the script was handed to the async dispatcher (queued — outcome arrives later as a poll event — or refused at the queue cap), so this Output carries no execution output and resume replay must skip the block
+   */
+  asyncDispatched?: boolean;
   /**
    * Names of tools registered during this execution
    */


### PR DESCRIPTION
## Summary
- Bump pinned claude-code CLI 2.1.233 → 2.1.234 in the isolated npm toolchain lockfile and vendored package (all platform variants + sdk-tools.d.ts).

## Test plan
- [x] Diff reviewed: version bump only, no other changes